### PR TITLE
Refactor controllers/model to User model

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -30,4 +30,6 @@ end
 
 group :test do
   gem 'simplecov', require: false
+  gem 'vcr'
+  gem 'webmock'
 end

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -58,6 +58,8 @@ GEM
       ffi (~> 1.0, >= 1.0.11)
     coderay (1.1.1)
     concurrent-ruby (1.0.1)
+    crack (0.4.3)
+      safe_yaml (~> 1.0.0)
     database_cleaner (1.5.1)
     debug_inspector (0.0.2)
     diff-lcs (1.2.5)
@@ -74,6 +76,7 @@ GEM
       thor (~> 0.14)
     globalid (0.3.6)
       activesupport (>= 4.1.0)
+    hashdiff (0.3.0)
     httparty (0.13.7)
       json (~> 1.8)
       multi_xml (>= 0.5.2)
@@ -160,6 +163,7 @@ GEM
       rspec-support (~> 3.4.0)
     rspec-support (3.4.1)
     rubyzip (1.2.0)
+    safe_yaml (1.0.4)
     sass (3.4.22)
     sass-rails (5.0.4)
       railties (>= 4.0.0, < 5.0)
@@ -197,11 +201,16 @@ GEM
       thread_safe (~> 0.1)
     uglifier (3.0.0)
       execjs (>= 0.3.0, < 3)
+    vcr (3.0.1)
     web-console (2.3.0)
       activemodel (>= 4.0)
       binding_of_caller (>= 0.7.2)
       railties (>= 4.0)
       sprockets-rails (>= 2.0, < 4.0)
+    webmock (1.24.2)
+      addressable (>= 2.3.6)
+      crack (>= 0.3.2)
+      hashdiff
     websocket (1.2.2)
     xpath (2.0.0)
       nokogiri (~> 1.3)
@@ -232,7 +241,9 @@ DEPENDENCIES
   simplecov
   spring
   uglifier (>= 1.3.0)
+  vcr
   web-console (~> 2.0)
+  webmock
 
 BUNDLED WITH
    1.11.2

--- a/app/controllers/participant/users_controller.rb
+++ b/app/controllers/participant/users_controller.rb
@@ -1,0 +1,19 @@
+class Participant::UsersController < ApplicationController
+  def create
+    token_hash = AndMeAuthService.get_token(params[:code])
+    user_info = AndMeAuthService.get_user_info(token_hash[:access_token])
+    credentials = ParticipantCredential.find_or_create_from_auth(token_hash, user_info)
+    credentials.user = User.find_or_create_from_auth(user_info)
+    user = credentials.user
+
+    if user
+      session[:user_id] = user.id
+    end
+    redirect_to root_path
+  end
+
+  def destroy
+    session.clear
+    redirect_to root_path
+  end
+end

--- a/app/controllers/participants/sessions_controller.rb
+++ b/app/controllers/participants/sessions_controller.rb
@@ -1,0 +1,18 @@
+class Participant::SessionsController < ApplicationController
+  def create
+  auth = AndMeAuthService.new
+  binding.pry
+    token = auth.get_token(params[:code])
+    user_info = auth.get_user_info(token)
+    user = User.find_or_create_with_auth(token, user_info)
+    if user
+      session[:user_id] = user.id
+    end
+    redirect_to root_path
+  end
+
+  def destroy
+    session.clear
+    redirect_to root_path
+  end
+end

--- a/app/models/participant_credential.rb
+++ b/app/models/participant_credential.rb
@@ -1,0 +1,12 @@
+class ParticipantCredential < ActiveRecord::Base
+  belongs_to :user
+  validates :uid, uniqueness: true
+
+  def self.find_or_create_from_auth(token_hash, user_info)
+    where(uid: user_info[:uid]).first_or_create do | participant_credential |
+      participant_credential.uid = user_info[:uid]
+      participant_credential.access_token = token_hash[:access_token]
+      participant_credential.refresh_token = token_hash[:refresh_token]
+    end
+  end
+end

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -1,13 +1,12 @@
 class User < ActiveRecord::Base
-  def self.find_or_create_with_auth(token, user_info)
-    where(uid: user_info[:uid]).first_or_create do |new_user|
-      new_user.access_token     = token[:access_token]
-      new_user.refresh_token    = token[:refresh_token]
-      new_user.email            = user_info[:email]
-      new_user.uid              = user_info[:uid]
-      new_user.first_name       = user_info[:first_name]
-      new_user.last_name        = user_info[:last_name]
+  has_one :participant_credential
+  validates :email, presence: true
 
+  def self.find_or_create_from_auth(user_info)
+    where(email: user_info[:email]).first_or_create do |user|
+      user.first_name   = user_info[:first_name]
+      user.last_name    = user_info[:last_name]
+      user.email        = user_info[:email]
     end
   end
 end

--- a/app/services/and_me_auth_service.rb
+++ b/app/services/and_me_auth_service.rb
@@ -1,5 +1,5 @@
 class AndMeAuthService
-  def get_token(code)
+  def self.get_token(code)
     token_response = {}
     response = Net::HTTP.post_form(URI("https://api.23andme.com/token"), token_params(code)).body
     parsed  = JSON.parse(response)
@@ -8,13 +8,13 @@ class AndMeAuthService
     token_response
   end
 
-  def get_user_info(token)
+  def self.get_user_info(token)
     service = UserService.new(token)
-    {profile_id: service.profile_id, email: service.email, first_name: service.first_name}
+    {uid: service.uid, email: service.email, first_name: service.first_name, last_name: service.last_name}
   end
 
   private
-    def token_params(code)
+    def self.token_params(code)
       {
         "client_id"         => ENV["23_and_me_id"],
         "client_secret"     => ENV["23_and_me_secret"],

--- a/app/services/user_service.rb
+++ b/app/services/user_service.rb
@@ -10,15 +10,18 @@ class UserService < AndMeApiService
     response["email"]
   end
 
-  def profile_id
+  def uid
     response = get("/user")
     response["profiles"].first["id"]
   end
 
   def first_name
-    response = get("/names/#{profile_id}")
+    response = get("/names/#{uid}")
     response["first_name"]
   end
 
-  private
+  def last_name
+    response = get("/names/#{uid}")
+    response["last_name"]
+  end
 end

--- a/config/database.yml
+++ b/config/database.yml
@@ -9,6 +9,10 @@ development:
   <<: *default
   database: genome_match_maker_development
 
+test:
+  <<: *default
+  database: genome_match_maker_development
+
 production:
   <<: *default
   database: genome_match_maker_production

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -1,4 +1,4 @@
 Rails.application.routes.draw do
   root to: "static_pages#landing"
-  get "/auth/and_me/callback", to: "participant/sessions#create"
+  get "/auth/and_me/callback", to: "participant/users#create"
 end

--- a/db/migrate/20160419225542_create_users.rb
+++ b/db/migrate/20160419225542_create_users.rb
@@ -1,12 +1,10 @@
 class CreateUsers < ActiveRecord::Migration
   def change
     create_table :users do |t|
-      t.string :email
-      t.string :uid
-      t.string :access_token
-      t.string :refresh_token
       t.string :first_name
       t.string :last_name
+      t.string :password
+      t.string :email
 
       t.timestamps null: false
     end

--- a/db/migrate/20160419231421_create_participant_credentials.rb
+++ b/db/migrate/20160419231421_create_participant_credentials.rb
@@ -1,0 +1,11 @@
+class CreateParticipantCredentials < ActiveRecord::Migration
+  def change
+    create_table :participant_credentials do |t|
+      t.string :access_token
+      t.string :refresh_token
+      t.string :uid
+
+      t.timestamps null: false
+    end
+  end
+end

--- a/db/migrate/20160419231523_add_user_to_participant_credential.rb
+++ b/db/migrate/20160419231523_add_user_to_participant_credential.rb
@@ -1,0 +1,5 @@
+class AddUserToParticipantCredential < ActiveRecord::Migration
+  def change
+    add_reference :participant_credentials, :user, index: true, foreign_key: true
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -11,20 +11,30 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20160419121722) do
+ActiveRecord::Schema.define(version: 20160419231523) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
 
-  create_table "users", force: :cascade do |t|
-    t.string   "email"
-    t.string   "uid"
+  create_table "participant_credentials", force: :cascade do |t|
     t.string   "access_token"
     t.string   "refresh_token"
-    t.string   "first_name"
-    t.string   "last_name"
+    t.string   "uid"
     t.datetime "created_at",    null: false
     t.datetime "updated_at",    null: false
+    t.integer  "user_id"
   end
 
+  add_index "participant_credentials", ["user_id"], name: "index_participant_credentials_on_user_id", using: :btree
+
+  create_table "users", force: :cascade do |t|
+    t.string   "first_name"
+    t.string   "last_name"
+    t.string   "password"
+    t.string   "email"
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
+  end
+
+  add_foreign_key "participant_credentials", "users"
 end

--- a/spec/cassettes/auth_service_and_token.yml
+++ b/spec/cassettes/auth_service_and_token.yml
@@ -1,0 +1,126 @@
+---
+http_interactions:
+- request:
+    method: post
+    uri: https://api.23andme.com/token
+    body:
+      encoding: US-ASCII
+      string: client_id=fa14c16e8d247c33723730c697802dd9&client_secret=0ff970b94a7ccdd3f44f5490787ea788&grant_type=authorization_code&code=48deb47b3a030ab6e63e2e946b64a73f&redirect_uri=http%3A%2F%2Flocalhost%3A3000%2Fauth%2Fand_me%2Fcallback&scope=basic+haplogroups+email+ancestry+names+profile%3Aread+profile%3Awrite
+    headers:
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+      User-Agent:
+      - Ruby
+      Host:
+      - api.23andme.com
+      Content-Type:
+      - application/x-www-form-urlencoded
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Server:
+      - cloudflare-nginx
+      Date:
+      - Wed, 20 Apr 2016 03:48:57 GMT
+      Content-Type:
+      - application/json
+      Transfer-Encoding:
+      - chunked
+      Connection:
+      - keep-alive
+      Set-Cookie:
+      - NSC_bqj-wjq-ttm=ffffffff09090e6c45525d5f4f58455e445a4a42378b;path=/;secure;httponly
+      - __cfduid=d01448614f2ab5a531720cf05561c6bf31461124137; expires=Thu, 20-Apr-17
+        03:48:57 GMT; path=/; domain=.23andme.com; HttpOnly
+      Vary:
+      - Cookie
+      Cache-Control:
+      - no-store
+      X-Frame-Options:
+      - SAMEORIGIN
+      Cf-Ray:
+      - 29659fa1c834261d-DFW
+    body:
+      encoding: ASCII-8BIT
+      string: '{"access_token": "2c50d9a1c7e0736c68b686d512d58c47", "token_type":
+        "bearer", "expires_in": 86400, "refresh_token": "afb1aaa75da46eaa9ea3630cf21117a2",
+        "scope": "profile:write haplogroups names ancestry basic email profile:read"}'
+    http_version: 
+  recorded_at: Wed, 20 Apr 2016 03:48:57 GMT
+- request:
+    method: get
+    uri: https://api.23andme.com/1/user
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Authorization:
+      - Bearer
+  response:
+    status:
+      code: 301
+      message: MOVED PERMANENTLY
+    headers:
+      Server:
+      - cloudflare-nginx
+      Date:
+      - Wed, 20 Apr 2016 03:49:14 GMT
+      Content-Length:
+      - '0'
+      Connection:
+      - keep-alive
+      Set-Cookie:
+      - NSC_bqj-wjq-ttm=ffffffff09090e9145525d5f4f58455e445a4a42378b;path=/;secure;httponly
+      - __cfduid=d935274af060c181232224dd704956e8b1461124153; expires=Thu, 20-Apr-17
+        03:49:13 GMT; path=/; domain=.23andme.com; HttpOnly
+      X-Frame-Options:
+      - SAMEORIGIN
+      Location:
+      - https://api.23andme.com/1/user/
+      Cf-Ray:
+      - 2965a00a3de31fbe-DFW
+    body:
+      encoding: UTF-8
+      string: ''
+    http_version: 
+  recorded_at: Wed, 20 Apr 2016 03:49:14 GMT
+- request:
+    method: get
+    uri: https://api.23andme.com/1/user/
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Authorization:
+      - Bearer
+      Cookie:
+      - __cfduid=d935274af060c181232224dd704956e8b1461124153; NSC_bqj-wjq-ttm=ffffffff09090e9145525d5f4f58455e445a4a42378b;path=/;secure;httponly
+  response:
+    status:
+      code: 401
+      message: UNAUTHORIZED
+    headers:
+      Server:
+      - cloudflare-nginx
+      Date:
+      - Wed, 20 Apr 2016 03:49:14 GMT
+      Content-Type:
+      - application/json
+      Content-Length:
+      - '75'
+      Connection:
+      - keep-alive
+      X-Frame-Options:
+      - SAMEORIGIN
+      Cf-Ray:
+      - 2965a00d170b2012-DFW
+    body:
+      encoding: UTF-8
+      string: '{"error_description": "Invalid token specified.", "error": "invalid_token"}'
+    http_version: 
+  recorded_at: Wed, 20 Apr 2016 03:49:14 GMT
+recorded_with: VCR 3.0.1

--- a/spec/cassettes/service_and_token.yml
+++ b/spec/cassettes/service_and_token.yml
@@ -1,0 +1,51 @@
+---
+http_interactions:
+- request:
+    method: post
+    uri: https://api.23andme.com/token
+    body:
+      encoding: US-ASCII
+      string: client_id=fa14c16e8d247c33723730c697802dd9&client_secret=0ff970b94a7ccdd3f44f5490787ea788&grant_type=authorization_code&code=cb3c8ac5543f636dc1759b77a5e3ee32&redirect_uri=http%3A%2F%2Flocalhost%3A3000%2Fauth%2Fand_me%2Fcallback&scope=basic+haplogroups+email+ancestry+names+profile%3Aread+profile%3Awrite
+    headers:
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+      User-Agent:
+      - Ruby
+      Host:
+      - api.23andme.com
+      Content-Type:
+      - application/x-www-form-urlencoded
+  response:
+    status:
+      code: 400
+      message: OK
+    headers:
+      Server:
+      - cloudflare-nginx
+      Date:
+      - Wed, 20 Apr 2016 03:44:14 GMT
+      Content-Type:
+      - application/json
+      Content-Length:
+      - '99'
+      Connection:
+      - keep-alive
+      Set-Cookie:
+      - NSC_bqj-wjq-ttm=ffffffff09090e9145525d5f4f58455e445a4a42378b;path=/;secure;httponly
+      - __cfduid=d42f75342241be48068221cc152cf744b1461123854; expires=Thu, 20-Apr-17
+        03:44:14 GMT; path=/; domain=.23andme.com; HttpOnly
+      Vary:
+      - Cookie
+      X-Frame-Options:
+      - SAMEORIGIN
+      Cf-Ray:
+      - 296598b863a50962-DFW
+    body:
+      encoding: UTF-8
+      string: '{"error_description": "Invalid code: cb3c8ac5543f636dc1759b77a5e3ee32",
+        "error": "invalid_request"}'
+    http_version: 
+  recorded_at: Wed, 20 Apr 2016 03:44:14 GMT
+recorded_with: VCR 3.0.1

--- a/spec/cassettes/user_service.yml
+++ b/spec/cassettes/user_service.yml
@@ -1,0 +1,393 @@
+---
+http_interactions:
+- request:
+    method: get
+    uri: https://api.23andme.com/1/user
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Authorization:
+      - Bearer 2703f521e98f18f434e61f13123fa140
+  response:
+    status:
+      code: 301
+      message: MOVED PERMANENTLY
+    headers:
+      Server:
+      - cloudflare-nginx
+      Date:
+      - Wed, 20 Apr 2016 04:08:47 GMT
+      Content-Length:
+      - '0'
+      Connection:
+      - keep-alive
+      Set-Cookie:
+      - NSC_bqj-wjq-ttm=ffffffff09090e6f45525d5f4f58455e445a4a42378b;path=/;secure;httponly
+      - __cfduid=d2ba0b117313e12aa58817c4cf58700861461125327; expires=Thu, 20-Apr-17
+        04:08:47 GMT; path=/; domain=.23andme.com; HttpOnly
+      X-Frame-Options:
+      - SAMEORIGIN
+      Location:
+      - https://api.23andme.com/1/user/
+      Cf-Ray:
+      - 2965bcae044d092c-DFW
+    body:
+      encoding: UTF-8
+      string: ''
+    http_version: 
+  recorded_at: Wed, 20 Apr 2016 04:08:47 GMT
+- request:
+    method: get
+    uri: https://api.23andme.com/1/user/
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Authorization:
+      - Bearer 2703f521e98f18f434e61f13123fa140
+      Cookie:
+      - __cfduid=d2ba0b117313e12aa58817c4cf58700861461125327; NSC_bqj-wjq-ttm=ffffffff09090e6f45525d5f4f58455e445a4a42378b;path=/;secure;httponly
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Server:
+      - cloudflare-nginx
+      Date:
+      - Wed, 20 Apr 2016 04:08:47 GMT
+      Content-Type:
+      - application/json
+      Content-Length:
+      - '87'
+      Connection:
+      - keep-alive
+      X-Frame-Options:
+      - SAMEORIGIN
+      Cf-Ray:
+      - 2965bcb0badf261d-DFW
+    body:
+      encoding: UTF-8
+      string: '{"id": "f095cb38d4c563c9", "profiles": [{"genotyped": true, "id": "b9e65773cfcdadfd"}]}'
+    http_version: 
+  recorded_at: Wed, 20 Apr 2016 04:08:47 GMT
+- request:
+    method: get
+    uri: https://api.23andme.com/1/user/?email=true
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Authorization:
+      - Bearer 2703f521e98f18f434e61f13123fa140
+      Cookie:
+      - __cfduid=d2ba0b117313e12aa58817c4cf58700861461125327; NSC_bqj-wjq-ttm=ffffffff09090e6f45525d5f4f58455e445a4a42378b;path=/;secure;httponly
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Server:
+      - cloudflare-nginx
+      Date:
+      - Wed, 20 Apr 2016 04:08:48 GMT
+      Content-Type:
+      - application/json
+      Content-Length:
+      - '116'
+      Connection:
+      - keep-alive
+      X-Frame-Options:
+      - SAMEORIGIN
+      Cf-Ray:
+      - 2965bcb4a5b7092c-DFW
+    body:
+      encoding: UTF-8
+      string: '{"id": "f095cb38d4c563c9", "profiles": [{"genotyped": true, "id": "b9e65773cfcdadfd"}],
+        "email": "heidih@gmail.com"}'
+    http_version: 
+  recorded_at: Wed, 20 Apr 2016 04:08:48 GMT
+- request:
+    method: get
+    uri: https://api.23andme.com/1/user
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Authorization:
+      - Bearer 2703f521e98f18f434e61f13123fa140
+      Cookie:
+      - __cfduid=d2ba0b117313e12aa58817c4cf58700861461125327; NSC_bqj-wjq-ttm=ffffffff09090e6f45525d5f4f58455e445a4a42378b;path=/;secure;httponly
+  response:
+    status:
+      code: 301
+      message: MOVED PERMANENTLY
+    headers:
+      Server:
+      - cloudflare-nginx
+      Date:
+      - Wed, 20 Apr 2016 04:08:48 GMT
+      Content-Length:
+      - '0'
+      Connection:
+      - keep-alive
+      X-Frame-Options:
+      - SAMEORIGIN
+      Location:
+      - https://api.23andme.com/1/user/
+      Cf-Ray:
+      - 2965bcb706672635-DFW
+    body:
+      encoding: UTF-8
+      string: ''
+    http_version: 
+  recorded_at: Wed, 20 Apr 2016 04:08:48 GMT
+- request:
+    method: get
+    uri: https://api.23andme.com/1/user/
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Authorization:
+      - Bearer 2703f521e98f18f434e61f13123fa140
+      Cookie:
+      - __cfduid=d2ba0b117313e12aa58817c4cf58700861461125327; NSC_bqj-wjq-ttm=ffffffff09090e6f45525d5f4f58455e445a4a42378b;path=/;secure;httponly
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Server:
+      - cloudflare-nginx
+      Date:
+      - Wed, 20 Apr 2016 04:08:48 GMT
+      Content-Type:
+      - application/json
+      Content-Length:
+      - '87'
+      Connection:
+      - keep-alive
+      X-Frame-Options:
+      - SAMEORIGIN
+      Cf-Ray:
+      - 2965bcb853fd1fa6-DFW
+    body:
+      encoding: UTF-8
+      string: '{"id": "f095cb38d4c563c9", "profiles": [{"genotyped": true, "id": "b9e65773cfcdadfd"}]}'
+    http_version: 
+  recorded_at: Wed, 20 Apr 2016 04:08:48 GMT
+- request:
+    method: get
+    uri: https://api.23andme.com/1/names/b9e65773cfcdadfd
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Authorization:
+      - Bearer 2703f521e98f18f434e61f13123fa140
+      Cookie:
+      - __cfduid=d2ba0b117313e12aa58817c4cf58700861461125327; NSC_bqj-wjq-ttm=ffffffff09090e6f45525d5f4f58455e445a4a42378b;path=/;secure;httponly
+  response:
+    status:
+      code: 301
+      message: MOVED PERMANENTLY
+    headers:
+      Server:
+      - cloudflare-nginx
+      Date:
+      - Wed, 20 Apr 2016 04:08:49 GMT
+      Content-Length:
+      - '0'
+      Connection:
+      - keep-alive
+      X-Frame-Options:
+      - SAMEORIGIN
+      Location:
+      - https://api.23andme.com/1/names/b9e65773cfcdadfd/
+      Cf-Ray:
+      - 2965bcbb03aa0962-DFW
+    body:
+      encoding: UTF-8
+      string: ''
+    http_version: 
+  recorded_at: Wed, 20 Apr 2016 04:08:49 GMT
+- request:
+    method: get
+    uri: https://api.23andme.com/1/names/b9e65773cfcdadfd/
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Authorization:
+      - Bearer 2703f521e98f18f434e61f13123fa140
+      Cookie:
+      - __cfduid=d2ba0b117313e12aa58817c4cf58700861461125327; NSC_bqj-wjq-ttm=ffffffff09090e6f45525d5f4f58455e445a4a42378b;path=/;secure;httponly
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Server:
+      - cloudflare-nginx
+      Date:
+      - Wed, 20 Apr 2016 04:08:50 GMT
+      Content-Type:
+      - application/json
+      Content-Length:
+      - '72'
+      Connection:
+      - keep-alive
+      X-Frame-Options:
+      - SAMEORIGIN
+      Cf-Ray:
+      - 2965bcc309de261d-DFW
+    body:
+      encoding: UTF-8
+      string: '{"first_name": "Heidi", "last_name": "Hoopes", "id": "b9e65773cfcdadfd"}'
+    http_version: 
+  recorded_at: Wed, 20 Apr 2016 04:08:50 GMT
+- request:
+    method: get
+    uri: https://api.23andme.com/1/user
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Authorization:
+      - Bearer 2703f521e98f18f434e61f13123fa140
+      Cookie:
+      - __cfduid=d2ba0b117313e12aa58817c4cf58700861461125327; NSC_bqj-wjq-ttm=ffffffff09090e6f45525d5f4f58455e445a4a42378b;path=/;secure;httponly
+  response:
+    status:
+      code: 301
+      message: MOVED PERMANENTLY
+    headers:
+      Server:
+      - cloudflare-nginx
+      Date:
+      - Wed, 20 Apr 2016 04:08:50 GMT
+      Content-Length:
+      - '0'
+      Connection:
+      - keep-alive
+      X-Frame-Options:
+      - SAMEORIGIN
+      Location:
+      - https://api.23andme.com/1/user/
+      Cf-Ray:
+      - 2965bcc4ed9a1ff4-DFW
+    body:
+      encoding: UTF-8
+      string: ''
+    http_version: 
+  recorded_at: Wed, 20 Apr 2016 04:08:50 GMT
+- request:
+    method: get
+    uri: https://api.23andme.com/1/user/
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Authorization:
+      - Bearer 2703f521e98f18f434e61f13123fa140
+      Cookie:
+      - __cfduid=d2ba0b117313e12aa58817c4cf58700861461125327; NSC_bqj-wjq-ttm=ffffffff09090e6f45525d5f4f58455e445a4a42378b;path=/;secure;httponly
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Server:
+      - cloudflare-nginx
+      Date:
+      - Wed, 20 Apr 2016 04:08:51 GMT
+      Content-Type:
+      - application/json
+      Content-Length:
+      - '87'
+      Connection:
+      - keep-alive
+      X-Frame-Options:
+      - SAMEORIGIN
+      Cf-Ray:
+      - 2965bcc6e2e6094a-DFW
+    body:
+      encoding: UTF-8
+      string: '{"id": "f095cb38d4c563c9", "profiles": [{"genotyped": true, "id": "b9e65773cfcdadfd"}]}'
+    http_version: 
+  recorded_at: Wed, 20 Apr 2016 04:08:51 GMT
+- request:
+    method: get
+    uri: https://api.23andme.com/1/names/b9e65773cfcdadfd
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Authorization:
+      - Bearer 2703f521e98f18f434e61f13123fa140
+      Cookie:
+      - __cfduid=d2ba0b117313e12aa58817c4cf58700861461125327; NSC_bqj-wjq-ttm=ffffffff09090e6f45525d5f4f58455e445a4a42378b;path=/;secure;httponly
+  response:
+    status:
+      code: 301
+      message: MOVED PERMANENTLY
+    headers:
+      Server:
+      - cloudflare-nginx
+      Date:
+      - Wed, 20 Apr 2016 04:08:51 GMT
+      Content-Type:
+      - __builtin__:__call__.close
+      Content-Length:
+      - '0'
+      Connection:
+      - keep-alive
+      X-Frame-Options:
+      - SAMEORIGIN
+      Location:
+      - https://api.23andme.com/1/names/b9e65773cfcdadfd/
+      Cf-Ray:
+      - 2965bcc855eb03d6-DFW
+    body:
+      encoding: UTF-8
+      string: ''
+    http_version: 
+  recorded_at: Wed, 20 Apr 2016 04:08:51 GMT
+- request:
+    method: get
+    uri: https://api.23andme.com/1/names/b9e65773cfcdadfd/
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Authorization:
+      - Bearer 2703f521e98f18f434e61f13123fa140
+      Cookie:
+      - __cfduid=d2ba0b117313e12aa58817c4cf58700861461125327; NSC_bqj-wjq-ttm=ffffffff09090e6f45525d5f4f58455e445a4a42378b;path=/;secure;httponly
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Server:
+      - cloudflare-nginx
+      Date:
+      - Wed, 20 Apr 2016 04:08:51 GMT
+      Content-Type:
+      - application/json
+      Content-Length:
+      - '72'
+      Connection:
+      - keep-alive
+      X-Frame-Options:
+      - SAMEORIGIN
+      Cf-Ray:
+      - 2965bcc9ace5261d-DFW
+    body:
+      encoding: UTF-8
+      string: '{"first_name": "Heidi", "last_name": "Hoopes", "id": "b9e65773cfcdadfd"}'
+    http_version: 
+  recorded_at: Wed, 20 Apr 2016 04:08:51 GMT
+recorded_with: VCR 3.0.1

--- a/spec/factories.rb
+++ b/spec/factories.rb
@@ -1,10 +1,13 @@
 FactoryGirl.define do
-  factory :user do
-    email "MyString"
-    uid "MyString"
+  factory :participant_credential do
     access_token "MyString"
     refresh_token "MyString"
+    uid "MyString"
+  end
+  factory :user do
     first_name "MyString"
     last_name "MyString"
+    password "MyString"
+    email "MyString"
   end
 end

--- a/spec/models/and_me_auth_service_spec.rb
+++ b/spec/models/and_me_auth_service_spec.rb
@@ -1,0 +1,16 @@
+require 'rails_helper'
+
+RSpec.describe AndMeAuthService do
+  describe "api call token endpoint with access code" do
+    it "gets tokens back" do
+
+      VCR.use_cassette("auth service and token") do
+        code = "48deb47b3a030ab6e63e2e946b64a73f"
+        response = AndMeAuthService.get_token(code)
+
+        expect(response[:refresh_token]).not_to be_nil
+        expect(response[:access_token]).not_to be_nil
+      end
+    end
+  end
+end

--- a/spec/models/participant_credential_spec.rb
+++ b/spec/models/participant_credential_spec.rb
@@ -1,0 +1,23 @@
+require 'rails_helper'
+
+RSpec.describe ParticipantCredential, type: :model do
+  it { should belong_to (:user) }
+  it {should validate_uniqueness_of (:uid)}
+
+  describe "find_or_create_with_auth" do
+    it "creates a new participant_credentials from token_hash and user_info" do
+      user_info = { uid: "a326bal320"
+      }
+      token_hash = {  access_token: "sample_access_token",
+                      refresh_token: "sample_refresh_token",
+      }
+
+      expect(ParticipantCredential.count).to eq(0)
+      ParticipantCredential.find_or_create_from_auth(token_hash, user_info)
+      expect(ParticipantCredential.count).to eq(1)
+      expect(ParticipantCredential.first.uid).to eq(user_info[:uid])
+      expect(ParticipantCredential.first.access_token).to eq(token_hash[:access_token])
+      expect(ParticipantCredential.first.refresh_token).to eq(token_hash[:refresh_token])
+    end
+  end
+end

--- a/spec/models/user_service_spec.rb
+++ b/spec/models/user_service_spec.rb
@@ -1,0 +1,22 @@
+require 'rails_helper'
+
+RSpec.describe UserService do
+  describe "service calls api for user info" do
+    it "receives information back" do
+      VCR.use_cassette("user service") do
+        token       = valid_token
+        service     = UserService.new(token)
+
+        uid         = service.uid
+        email       = service.email
+        first_name  = service.first_name
+        last_name   = service.last_name
+
+        expect(uid).to eq("b9e65773cfcdadfd")
+        expect(first_name).to eq("Heidi")
+        expect(last_name).to eq("Hoopes")
+        expect(email).to eq("heidih@gmail.com")
+      end
+    end
+  end
+end

--- a/spec/models/user_spec.rb
+++ b/spec/models/user_spec.rb
@@ -1,5 +1,20 @@
 require 'rails_helper'
 
 RSpec.describe User, type: :model do
-  pending "add some examples to (or delete) #{__FILE__}"
+  it { should validate_presence_of (:email) }
+
+  describe "find_or_create_with_auth" do
+    it "creates a new user from user_info hash" do
+      user_info = { first_name: "Sally",
+                    last_name:  "Golightly",
+                    email:      "sally@example.com"
+      }
+      expect(User.count).to eq(0)
+      User.find_or_create_from_auth(user_info)
+      expect(User.count).to eq(1)
+      expect(User.first.first_name).to eq(user_info[:first_name])
+      expect(User.first.last_name).to eq(user_info[:last_name])
+      expect(User.first.email).to eq(user_info[:email])
+    end
+  end
 end

--- a/spec/rails_helper.rb
+++ b/spec/rails_helper.rb
@@ -5,6 +5,9 @@ require File.expand_path('../../config/environment', __FILE__)
 abort("The Rails environment is running in production mode!") if Rails.env.production?
 require 'spec_helper'
 require 'rspec/rails'
+require 'webmock'
+require 'vcr'
+
 # Add additional requires below this line. Rails is not loaded until this point!
 
 # Requires supporting ruby files with custom matchers and macros, etc, in
@@ -26,7 +29,13 @@ require 'rspec/rails'
 # If you are not using ActiveRecord, you can remove this line.
 ActiveRecord::Migration.maintain_test_schema!
 
+VCR.configure do |c|
+  c.cassette_library_dir = "spec/cassettes"
+  c.hook_into :webmock
+end
+
 RSpec.configure do |config|
+
   config.before(:suite) do
     DatabaseCleaner.clean_with(:truncation)
   end

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -44,60 +44,14 @@ RSpec.configure do |config|
 
   def token_response
     {
-      "access_token"=>"e2593d8f86166a583507e69373684dcc",
+      "access_token"=>"sample_access_token",
       "token_type"=>"bearer",
       "expires_in"=>86400,
-      "refresh_token"=>"d1ce2147eec93e11128a92bc1ab14514",
+      "refresh_token"=>"sample_refresh_token",
       "scope"=>"profile:write haplogroups names ancestry basic email profile:read"}
   end
 
-# The settings below are suggested to provide a good initial experience
-# with RSpec, but feel free to customize to your heart's content.
-=begin
-  # These two settings work together to allow you to limit a spec run
-  # to individual examples or groups you care about by tagging them with
-  # `:focus` metadata. When nothing is tagged with `:focus`, all examples
-  # get run.
-  config.filter_run :focus
-  config.run_all_when_everything_filtered = true
-
-  # Allows RSpec to persist some state between runs in order to support
-  # the `--only-failures` and `--next-failure` CLI options. We recommend
-  # you configure your source control system to ignore this file.
-  config.example_status_persistence_file_path = "spec/examples.txt"
-
-  # Limits the available syntax to the non-monkey patched syntax that is
-  # recommended. For more details, see:
-  #   - http://rspec.info/blog/2012/06/rspecs-new-expectation-syntax/
-  #   - http://www.teaisaweso.me/blog/2013/05/27/rspecs-new-message-expectation-syntax/
-  #   - http://rspec.info/blog/2014/05/notable-changes-in-rspec-3/#zero-monkey-patching-mode
-  config.disable_monkey_patching!
-
-  # Many RSpec users commonly either run the entire suite or an individual
-  # file, and it's useful to allow more verbose output when running an
-  # individual spec file.
-  if config.files_to_run.one?
-    # Use the documentation formatter for detailed output,
-    # unless a formatter has already been configured
-    # (e.g. via a command-line flag).
-    config.default_formatter = 'doc'
+  def valid_token
+    ENV["ACCESS_TOKEN"]
   end
-
-  # Print the 10 slowest examples and example groups at the
-  # end of the spec run, to help surface which specs are running
-  # particularly slow.
-  config.profile_examples = 10
-
-  # Run specs in random order to surface order dependencies. If you find an
-  # order dependency and want to debug it, you can fix the order by providing
-  # the seed, which is printed after each run.
-  #     --seed 1234
-  config.order = :random
-
-  # Seed global randomization in this process using the `--seed` CLI option.
-  # Setting this allows you to use `--seed` to deterministically reproduce
-  # test failures related to randomization by passing the same `--seed` value
-  # as the one that triggered the failure.
-  Kernel.srand config.seed
-=end
 end


### PR DESCRIPTION
Previously our user model used two different tables(participants and researchers) to
create the two roles. This refactor moves participants to the user class where
researcher will join them in a future branch. A separate user controller was
nested under participants, and attributes were sorted into User attributes
which will be shared with researchers, and a ParticipantCredential class to
store tokens.

Tests were written for these models and for the user service and authentication
service.

Future refactors that will have to build off this are:
- Adding a password in a separate view/path to store on the participant-user
- Adding a logout
- Adding a login that doesn't hit the api
- Adding a token refresh method

Closes #4 
Closes #9
