### PR TITLE
Make auth host a dynamic env var for production

### DIFF
--- a/app/helpers/auth_helper.rb
+++ b/app/helpers/auth_helper.rb
@@ -1,5 +1,9 @@
 module AuthHelper
   def client_id
     ENV["23_and_me_id"]
-  end 
+  end
+
+  def callback_host
+    ENV["callback_host"]
+  end
 end

--- a/app/views/static_pages/landing.html.erb
+++ b/app/views/static_pages/landing.html.erb
@@ -2,7 +2,7 @@
   <h1 class="text-center">Welcome to Genome Match Maker</h1>
   <div class="signup-participant col-md-6">
     <p class="text-center"><%= link_to "I am a participant",
-      "https://api.23andme.com/authorize/?redirect_uri=http://localhost:3000/auth/and_me/callback&response_type=code&client_id=" + client_id + "&scope=basic%20ancestry%20email%20haplogroups%20names%20profile:read%20profile:write" %></p>
+      "https://api.23andme.com/authorize/?redirect_uri=" + callback_host + "&response_type=code&client_id=" + client_id + "&scope=basic%20ancestry%20email%20haplogroups%20names%20profile:read%20profile:write" %></p>
     <p class="text-center">Sign in through 23 and Me</p>
   </div>
   <div class="signup-researcher col-md-6">


### PR DESCRIPTION
Similar to changing the 23A&M id to reflect which environment it's being used in,
also changed the callback URL for production and created a view helper for it.
