### PR TITLE
Add feature for participant matching study's snps

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -11,6 +11,7 @@ gem 'figaro'
 gem 'pg'
 gem 'httparty'
 gem 'rails_12factor', group: :production
+gem 'activerecord-import', '~> 0.4.0'
 
 group :development, :test do
   gem 'pry'
@@ -20,6 +21,7 @@ group :development, :test do
   gem 'selenium-webdriver'
   gem 'factory_girl_rails', '~> 4.0'
   gem 'shoulda-matchers', '~> 3.1'
+  gem 'faker'
 end
 
 group :development do

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -30,6 +30,8 @@ GEM
       activemodel (= 4.2.5.1)
       activesupport (= 4.2.5.1)
       arel (~> 6.0)
+    activerecord-import (0.4.1)
+      activerecord (>= 3.0)
     activesupport (4.2.5.1)
       i18n (~> 0.7)
       json (~> 1.7, >= 1.7.7)
@@ -71,6 +73,8 @@ GEM
     factory_girl_rails (4.6.0)
       factory_girl (~> 4.5.0)
       railties (>= 3.0.0)
+    faker (1.6.3)
+      i18n (~> 0.5)
     ffi (1.9.10)
     figaro (1.1.1)
       thor (~> 0.14)
@@ -221,11 +225,13 @@ PLATFORMS
   ruby
 
 DEPENDENCIES
+  activerecord-import (~> 0.4.0)
   bcrypt (~> 3.1.7)
   bootstrap-sass (~> 3.3.6)
   capybara
   database_cleaner
   factory_girl_rails (~> 4.0)
+  faker
   figaro
   httparty
   jbuilder (~> 2.0)

--- a/app/controllers/participant/users_controller.rb
+++ b/app/controllers/participant/users_controller.rb
@@ -1,5 +1,6 @@
 class Participant::UsersController < ApplicationController
   def create
+    binding.pry
     token_hash = AndMeAuthService.get_token(params[:code])
     user_info = AndMeAuthService.get_user_info(token_hash[:access_token])
     user = User.find_or_create_from_auth(user_info)

--- a/app/controllers/studies_controller.rb
+++ b/app/controllers/studies_controller.rb
@@ -1,0 +1,6 @@
+class StudiesController < ApplicationController
+  def show
+    @study = Study.find(params[:id])
+  end
+
+end

--- a/app/controllers/users_controller.rb
+++ b/app/controllers/users_controller.rb
@@ -2,10 +2,13 @@ class UsersController < ApplicationController
   def show
     @user = current_user
     if @user.researcher?
-      @studies = @user.studies if @user.studies
+      @studies = @user.studies
       render "researcher/users/show"
-    else
+    elsif @user.participant?
+      @matches = @user.matches unless @user.matches.nil?
       render "participants/users/show"
+    else
+      redirect_to root_path
     end
   end
 end

--- a/app/models/snp.rb
+++ b/app/models/snp.rb
@@ -1,7 +1,12 @@
 class Snp < ActiveRecord::Base
   belongs_to :study
+  belongs_to :user
   belongs_to :snp_value
   has_one :location, through: :snp_value
   belongs_to :snppable, polymorphic: true
   accepts_nested_attributes_for :snp_value
+
+  def create_for_participant(snp_array)
+    
+  end
 end

--- a/app/models/study.rb
+++ b/app/models/study.rb
@@ -1,7 +1,7 @@
 class Study < ActiveRecord::Base
   belongs_to :user
   has_many :snps, as: :snppable
-  has_many :snp_values, through: :snps
-  has_many :locations, through: :snp_values
+  has_many :snp_values, through: :snps, source: :snppable, source_type: "Study"
+  has_many :locations, through: :snp_values, source: :snppable, source_type: "Study"
   accepts_nested_attributes_for :snps
 end

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -3,6 +3,7 @@ class User < ActiveRecord::Base
   has_one :participant_credential, dependent: :destroy
   has_one :researcher_credential, dependent: :destroy
   has_many :studies
+  has_many :snps, as: :snppable
   validates :email, presence: true
 
   def self.find_or_create_from_auth(user_info)
@@ -24,5 +25,42 @@ class User < ActiveRecord::Base
 
   def full_name
     first_name.capitalize + " " + last_name.capitalize
+  end
+
+  def matches
+    matches = []
+    if self.participant?
+      generate_snps
+      svs = self.snps.all.collect {|snp| snp.snp_value }
+
+      Study.all.each do | study |
+        ssvs = study.snps.all.collect {|snp| snp.snp_value}
+        ssvs.each do |snp_value|
+          if svs.include?(snp_value)
+            matches << study
+          end
+        end
+      end
+    end
+    matches
+  end
+
+  def generate_snps
+    missing = []
+    locations =
+    self.snps.collect do |user_snp|
+      user_snp.location
+    end
+    Snp.where(snppable_type: "Study").all.each do | snp |
+      next if locations.include?(snp.location)
+      missing << snp.location.position
+    end
+    missing.each do |position|
+      service = SnpService.new(self.participant_credential.access_token, self)
+      bp = service.find_basepairs(position)
+      location = Location.find_by(position: position)
+      sv = SnpValue.where(base_pair: bp, location_id: location.id).first_or_create(base_pair: bp, location_id: location.id)
+      self.snps << Snp.create(snppable_type: "user", snppable_id: self.id, snp_value_id: sv.id)
+    end
   end
 end

--- a/app/services/and_me_auth_service.rb
+++ b/app/services/and_me_auth_service.rb
@@ -2,6 +2,7 @@ class AndMeAuthService
   def self.get_token(code)
     token_response = {}
     response = Net::HTTP.post_form(URI("https://api.23andme.com/token"), token_params(code)).body
+
     parsed  = JSON.parse(response)
     token_response[:refresh_token]   = parsed["refresh_token"]
     token_response[:access_token]    = parsed["access_token"]
@@ -21,7 +22,7 @@ class AndMeAuthService
         "grant_type"        => "authorization_code",
         "code"              => code,
         "redirect_uri"      => ENV["callback_host"],
-        "scope"             => "basic haplogroups email ancestry names profile:read profile:write",
+        "scope"             => "basic email genomes names",
       }
     end
 end

--- a/app/services/snp_service.rb
+++ b/app/services/snp_service.rb
@@ -1,0 +1,6 @@
+class SnpService < AndMeApiService
+  def find_basepairs(position)
+    response = get("/genotypes/#{@current_user.participant_credential.uid}/?locations=#{position}")
+    response[position]
+  end
+end

--- a/app/views/participants/users/show.html.erb
+++ b/app/views/participants/users/show.html.erb
@@ -1,0 +1,10 @@
+<h1>Participant Dashboard</h1>
+
+<h2>Your Research Studies</h2>
+  <% @matches.each do | match | %>
+    <p><%= link_to match.name, study_path(match) %>
+    <p><%= match.user.researcher_credential.organization %>
+    <p><%= match.description %>
+    <p>Based on your value of "<%= match.snps.first.snp_value.base_pair %>"
+      at the <%= match.snps.first.snp_value.location.position %> position.
+  <% end %>

--- a/app/views/researcher/users/show.html.erb
+++ b/app/views/researcher/users/show.html.erb
@@ -1,18 +1,22 @@
 <div class="container researcher">
-  <h1> <%= "Welcome, " + @user.full_name %></h1>
+  <h1>"Researcher Dashboard</h1>
 
   <h2>Your Studies</h2>
   <%= link_to "Create new study", new_researcher_study_path %>
 
-  <% if @studies %>
+  <% if @studies.empty? %>
+    <p>
+      We're sorry, no researchers have created studies at this time that match with your genome.
+    </p>
+  <% else %>
     <% @studies.each do | study | %>
       <div class="study-<%= study.id %>">
         <p><%= study.name %> </p>
         <p><%= study.description %> </p>
         <p> <% study.snps.each do |snp| %>
           SNP Location: <%= snp.snp_value.location.position + " (#{snp.snp_value.base_pair})" %>
+        <% end %>
       </div>
-      <% end %>
     <% end %>
   <% end %>
 </div>

--- a/app/views/static_pages/landing.html.erb
+++ b/app/views/static_pages/landing.html.erb
@@ -3,7 +3,7 @@
   <% unless current_user %>
     <div class="signup-participant col-md-6">
       <p class="text-center"><%= link_to "I am a participant",
-        "https://api.23andme.com/authorize/?redirect_uri=" + callback_host + "&response_type=code&client_id=" + client_id + "&scope=basic%20ancestry%20email%20haplogroups%20names%20profile:read%20profile:write" %></p>
+        "https://api.23andme.com/authorize/?redirect_uri=" + callback_host + "&response_type=code&client_id=" + client_id + "&scope=basic%20names%20email%20genomes" %></p>
       <p class="text-center">Sign in with 23andMe</p>
     </div>
     <div class="signup-researcher col-md-6">

--- a/app/views/users/show.html.erb
+++ b/app/views/users/show.html.erb
@@ -1,1 +1,0 @@
-<%= @user.first_name + " " + @user.last_name %>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -14,6 +14,8 @@ Rails.application.routes.draw do
   namespace :participants do
   end
 
+  resources :studies, only: [:show]
+  
   get "/dashboard", to: "users#show"
   post "/researcher_signup", to: "researcher/users#create"
 end

--- a/lib/tasks/generate.rake
+++ b/lib/tasks/generate.rake
@@ -1,19 +1,25 @@
 require 'csv'
+require 'activerecord-import'
 
 namespace :import do
   desc "Import shortened snp location list"
     task partial_locations: :environment do
+      positions = []
       CSV.foreach("data/partial_snps.csv", headers: true) do |row|
-        Location.create(position: row["snp"])
-        puts "Added #{row["snp"]}"
+        entry = Location.new(position: row["snp"])
+          puts "Added #{row["index"]}" if row["index"].to_i % 10 == 0
+          positions << entry
       end
+      Location.import positions
     end
 
     desc "Import shortened snp location list"
       task locations: :environment do
-        CSV.foreach("data/full_snps.csv", headers: true) do |row|
-          Location.create(position: row["snp"])
-          puts "Added #{row["snp"]}"
-        end
+        positions = []
+          CSV.foreach("data/full_snps.csv", headers: true) do |row|
+            positions << Location.new(position: row["snp"])
+            puts "Added #{row["index"]}" if row["index"].to_i % 100000 == 0
+          end
+          import = Location.import positions
       end
 end

--- a/spec/cassettes/auth_service_and_token.yml
+++ b/spec/cassettes/auth_service_and_token.yml
@@ -5,7 +5,7 @@ http_interactions:
     uri: https://api.23andme.com/token
     body:
       encoding: US-ASCII
-      string: client_id=fa14c16e8d247c33723730c697802dd9&client_secret=0ff970b94a7ccdd3f44f5490787ea788&grant_type=authorization_code&code=117311b1980c7626e5020a943f2fa0d7&redirect_uri=http%3A%2F%2Flocalhost%3A3000%2Fauth%2Fand_me%2Fcallback&scope=basic+haplogroups+email+ancestry+names+profile%3Aread+profile%3Awrite
+      string: client_id=fa14c16e8d247c33723730c697802dd9&client_secret=0ff970b94a7ccdd3f44f5490787ea788&grant_type=authorization_code&code=552ba8a755ed4878afcd567230b0141b&redirect_uri=http%3A%2F%2Flocalhost%3A3000%2Fauth%2Fand_me%2Fcallback&scope=basic+email+genomes+names
     headers:
       Accept-Encoding:
       - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
@@ -25,7 +25,7 @@ http_interactions:
       Server:
       - cloudflare-nginx
       Date:
-      - Fri, 22 Apr 2016 05:49:59 GMT
+      - Sun, 24 Apr 2016 01:10:15 GMT
       Content-Type:
       - application/json
       Transfer-Encoding:
@@ -33,9 +33,9 @@ http_interactions:
       Connection:
       - keep-alive
       Set-Cookie:
-      - NSC_bqj-wjq-ttm=ffffffff09090e9045525d5f4f58455e445a4a42378b;path=/;secure;httponly
-      - __cfduid=d8978acee6dfbbe53d0e69a3842c121651461304199; expires=Sat, 22-Apr-17
-        05:49:59 GMT; path=/; domain=.23andme.com; HttpOnly
+      - NSC_bqj-wjq-ttm=ffffffff09090e6f45525d5f4f58455e445a4a42378b;path=/;secure;httponly
+      - __cfduid=d2cd0ad9d52ef7af42d4a24808b7fb6b31461460215; expires=Mon, 24-Apr-17
+        01:10:15 GMT; path=/; domain=.23andme.com; HttpOnly
       Vary:
       - Cookie
       Cache-Control:
@@ -43,12 +43,12 @@ http_interactions:
       X-Frame-Options:
       - SAMEORIGIN
       Cf-Ray:
-      - 2976cbac2ad8263b-DFW
+      - 2985acab35040968-DFW
     body:
       encoding: ASCII-8BIT
-      string: '{"access_token": "25eb2fbf3e7ee4f14665a924ea9bd385", "token_type":
-        "bearer", "expires_in": 86400, "refresh_token": "64905f443caed5c975450c912e6e1791",
-        "scope": "profile:write haplogroups names ancestry basic email profile:read"}'
+      string: '{"access_token": "24f5626889e59fe2534317870a0c7464", "token_type":
+        "bearer", "expires_in": 86400, "refresh_token": "b176f8c06ad03e2f63a3ef84c6c05a6d",
+        "scope": "basic names email genomes"}'
     http_version: 
-  recorded_at: Fri, 22 Apr 2016 05:49:59 GMT
+  recorded_at: Sun, 24 Apr 2016 01:10:15 GMT
 recorded_with: VCR 3.0.1

--- a/spec/cassettes/snp_service.yml
+++ b/spec/cassettes/snp_service.yml
@@ -1,0 +1,77 @@
+---
+http_interactions:
+- request:
+    method: get
+    uri: https://api.23andme.com/1/genotypes/b9e65773cfcdadfd/?locations=rs3094315
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Authorization:
+      - Bearer 35f25c3211be51d4bfb5a0fd67f42ec0
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Server:
+      - cloudflare-nginx
+      Date:
+      - Sun, 24 Apr 2016 01:10:32 GMT
+      Content-Type:
+      - application/json
+      Content-Length:
+      - '45'
+      Connection:
+      - keep-alive
+      Set-Cookie:
+      - NSC_bqj-wjq-ttm=ffffffff09090e6c45525d5f4f58455e445a4a42378b;path=/;secure;httponly
+      - __cfduid=deb6773224f8cc908e396d7d79723ec271461460232; expires=Mon, 24-Apr-17
+        01:10:32 GMT; path=/; domain=.23andme.com; HttpOnly
+      X-Frame-Options:
+      - SAMEORIGIN
+      Cf-Ray:
+      - 2985ad167789263b-DFW
+    body:
+      encoding: UTF-8
+      string: '{"rs3094315": "AA", "id": "b9e65773cfcdadfd"}'
+    http_version: 
+  recorded_at: Sun, 24 Apr 2016 01:10:32 GMT
+- request:
+    method: get
+    uri: https://api.23andme.com/1/genotypes/b9e65773cfcdadfd/?locations=garbage
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Authorization:
+      - Bearer 35f25c3211be51d4bfb5a0fd67f42ec0
+  response:
+    status:
+      code: 400
+      message: BAD REQUEST
+    headers:
+      Server:
+      - cloudflare-nginx
+      Date:
+      - Sun, 24 Apr 2016 01:10:33 GMT
+      Content-Type:
+      - application/json
+      Content-Length:
+      - '73'
+      Connection:
+      - keep-alive
+      Set-Cookie:
+      - NSC_bqj-wjq-ttm=ffffffff09090e9045525d5f4f58455e445a4a42378b;path=/;secure;httponly
+      - __cfduid=d4e045e739beb83ccefdf982ab70b85881461460233; expires=Mon, 24-Apr-17
+        01:10:33 GMT; path=/; domain=.23andme.com; HttpOnly
+      X-Frame-Options:
+      - SAMEORIGIN
+      Cf-Ray:
+      - 2985ad19010d2030-DFW
+    body:
+      encoding: UTF-8
+      string: '{"error_description": "Invalid SNP: garbage", "error": "invalid_request"}'
+    http_version: 
+  recorded_at: Sun, 24 Apr 2016 01:10:33 GMT
+recorded_with: VCR 3.0.1

--- a/spec/cassettes/user_info.yml
+++ b/spec/cassettes/user_info.yml
@@ -8,7 +8,7 @@ http_interactions:
       string: ''
     headers:
       Authorization:
-      - Bearer f8b7ad0e4a4283185390b47bc4124740
+      - Bearer 35f25c3211be51d4bfb5a0fd67f42ec0
   response:
     status:
       code: 301
@@ -17,28 +17,28 @@ http_interactions:
       Server:
       - cloudflare-nginx
       Date:
-      - Fri, 22 Apr 2016 06:12:48 GMT
+      - Sun, 24 Apr 2016 01:10:29 GMT
       Content-Type:
-      - text/html; charset=utf-8
-      Transfer-Encoding:
-      - chunked
+      - __builtin__:__call__.close
+      Content-Length:
+      - '0'
       Connection:
       - keep-alive
       Set-Cookie:
-      - NSC_bqj-wjq-ttm=ffffffff09090e6e45525d5f4f58455e445a4a42378b;path=/;secure;httponly
-      - __cfduid=db635c9ff24004bb1658a1064c209cf1c1461305568; expires=Sat, 22-Apr-17
-        06:12:48 GMT; path=/; domain=.23andme.com; HttpOnly
+      - NSC_bqj-wjq-ttm=ffffffff09090e6d45525d5f4f58455e445a4a42378b;path=/;secure;httponly
+      - __cfduid=ddca76a5467e92d2a3d823eb0dfc91fb51461460229; expires=Mon, 24-Apr-17
+        01:10:29 GMT; path=/; domain=.23andme.com; HttpOnly
       X-Frame-Options:
       - SAMEORIGIN
       Location:
       - https://api.23andme.com/1/user/
       Cf-Ray:
-      - 2976ed18a4561fe2-DFW
+      - 2985ad02f6691fc4-DFW
     body:
       encoding: UTF-8
       string: ''
     http_version: 
-  recorded_at: Fri, 22 Apr 2016 06:12:48 GMT
+  recorded_at: Sun, 24 Apr 2016 01:10:29 GMT
 - request:
     method: get
     uri: https://api.23andme.com/1/user/
@@ -47,9 +47,9 @@ http_interactions:
       string: ''
     headers:
       Authorization:
-      - Bearer f8b7ad0e4a4283185390b47bc4124740
+      - Bearer 35f25c3211be51d4bfb5a0fd67f42ec0
       Cookie:
-      - __cfduid=db635c9ff24004bb1658a1064c209cf1c1461305568; NSC_bqj-wjq-ttm=ffffffff09090e6e45525d5f4f58455e445a4a42378b;path=/;secure;httponly
+      - __cfduid=ddca76a5467e92d2a3d823eb0dfc91fb51461460229; NSC_bqj-wjq-ttm=ffffffff09090e6d45525d5f4f58455e445a4a42378b;path=/;secure;httponly
   response:
     status:
       code: 200
@@ -58,7 +58,7 @@ http_interactions:
       Server:
       - cloudflare-nginx
       Date:
-      - Fri, 22 Apr 2016 06:12:48 GMT
+      - Sun, 24 Apr 2016 01:10:30 GMT
       Content-Type:
       - application/json
       Content-Length:
@@ -68,12 +68,12 @@ http_interactions:
       X-Frame-Options:
       - SAMEORIGIN
       Cf-Ray:
-      - 2976ed1adfb41ffa-DFW
+      - 2985ad0582da03dc-DFW
     body:
       encoding: UTF-8
       string: '{"id": "f095cb38d4c563c9", "profiles": [{"genotyped": true, "id": "b9e65773cfcdadfd"}]}'
     http_version: 
-  recorded_at: Fri, 22 Apr 2016 06:12:48 GMT
+  recorded_at: Sun, 24 Apr 2016 01:10:30 GMT
 - request:
     method: get
     uri: https://api.23andme.com/1/user/?email=true
@@ -82,9 +82,9 @@ http_interactions:
       string: ''
     headers:
       Authorization:
-      - Bearer f8b7ad0e4a4283185390b47bc4124740
+      - Bearer 35f25c3211be51d4bfb5a0fd67f42ec0
       Cookie:
-      - __cfduid=db635c9ff24004bb1658a1064c209cf1c1461305568; NSC_bqj-wjq-ttm=ffffffff09090e6e45525d5f4f58455e445a4a42378b;path=/;secure;httponly
+      - __cfduid=ddca76a5467e92d2a3d823eb0dfc91fb51461460229; NSC_bqj-wjq-ttm=ffffffff09090e6d45525d5f4f58455e445a4a42378b;path=/;secure;httponly
   response:
     status:
       code: 200
@@ -93,7 +93,7 @@ http_interactions:
       Server:
       - cloudflare-nginx
       Date:
-      - Fri, 22 Apr 2016 06:12:49 GMT
+      - Sun, 24 Apr 2016 01:10:30 GMT
       Content-Type:
       - application/json
       Content-Length:
@@ -103,13 +103,13 @@ http_interactions:
       X-Frame-Options:
       - SAMEORIGIN
       Cf-Ray:
-      - 2976ed1e1d271189-DFW
+      - 2985ad0714c20104-DFW
     body:
       encoding: UTF-8
       string: '{"id": "f095cb38d4c563c9", "profiles": [{"genotyped": true, "id": "b9e65773cfcdadfd"}],
         "email": "heidih@gmail.com"}'
     http_version: 
-  recorded_at: Fri, 22 Apr 2016 06:12:49 GMT
+  recorded_at: Sun, 24 Apr 2016 01:10:30 GMT
 - request:
     method: get
     uri: https://api.23andme.com/1/user
@@ -118,9 +118,9 @@ http_interactions:
       string: ''
     headers:
       Authorization:
-      - Bearer f8b7ad0e4a4283185390b47bc4124740
+      - Bearer 35f25c3211be51d4bfb5a0fd67f42ec0
       Cookie:
-      - __cfduid=db635c9ff24004bb1658a1064c209cf1c1461305568; NSC_bqj-wjq-ttm=ffffffff09090e6e45525d5f4f58455e445a4a42378b;path=/;secure;httponly
+      - __cfduid=ddca76a5467e92d2a3d823eb0dfc91fb51461460229; NSC_bqj-wjq-ttm=ffffffff09090e6d45525d5f4f58455e445a4a42378b;path=/;secure;httponly
   response:
     status:
       code: 301
@@ -129,9 +129,7 @@ http_interactions:
       Server:
       - cloudflare-nginx
       Date:
-      - Fri, 22 Apr 2016 06:12:49 GMT
-      Content-Type:
-      - __builtin__:__call__.close
+      - Sun, 24 Apr 2016 01:10:30 GMT
       Content-Length:
       - '0'
       Connection:
@@ -141,12 +139,12 @@ http_interactions:
       Location:
       - https://api.23andme.com/1/user/
       Cf-Ray:
-      - 2976ed1f90ee2018-DFW
+      - 2985ad09715e2623-DFW
     body:
       encoding: UTF-8
       string: ''
     http_version: 
-  recorded_at: Fri, 22 Apr 2016 06:12:49 GMT
+  recorded_at: Sun, 24 Apr 2016 01:10:30 GMT
 - request:
     method: get
     uri: https://api.23andme.com/1/user/
@@ -155,9 +153,9 @@ http_interactions:
       string: ''
     headers:
       Authorization:
-      - Bearer f8b7ad0e4a4283185390b47bc4124740
+      - Bearer 35f25c3211be51d4bfb5a0fd67f42ec0
       Cookie:
-      - __cfduid=db635c9ff24004bb1658a1064c209cf1c1461305568; NSC_bqj-wjq-ttm=ffffffff09090e6e45525d5f4f58455e445a4a42378b;path=/;secure;httponly
+      - __cfduid=ddca76a5467e92d2a3d823eb0dfc91fb51461460229; NSC_bqj-wjq-ttm=ffffffff09090e6d45525d5f4f58455e445a4a42378b;path=/;secure;httponly
   response:
     status:
       code: 200
@@ -166,7 +164,7 @@ http_interactions:
       Server:
       - cloudflare-nginx
       Date:
-      - Fri, 22 Apr 2016 06:12:49 GMT
+      - Sun, 24 Apr 2016 01:10:30 GMT
       Content-Type:
       - application/json
       Content-Length:
@@ -176,12 +174,12 @@ http_interactions:
       X-Frame-Options:
       - SAMEORIGIN
       Cf-Ray:
-      - 2976ed21b13b0968-DFW
+      - 2985ad0afa671ffa-DFW
     body:
       encoding: UTF-8
       string: '{"id": "f095cb38d4c563c9", "profiles": [{"genotyped": true, "id": "b9e65773cfcdadfd"}]}'
     http_version: 
-  recorded_at: Fri, 22 Apr 2016 06:12:49 GMT
+  recorded_at: Sun, 24 Apr 2016 01:10:31 GMT
 - request:
     method: get
     uri: https://api.23andme.com/1/names/b9e65773cfcdadfd
@@ -190,9 +188,9 @@ http_interactions:
       string: ''
     headers:
       Authorization:
-      - Bearer f8b7ad0e4a4283185390b47bc4124740
+      - Bearer 35f25c3211be51d4bfb5a0fd67f42ec0
       Cookie:
-      - __cfduid=db635c9ff24004bb1658a1064c209cf1c1461305568; NSC_bqj-wjq-ttm=ffffffff09090e6e45525d5f4f58455e445a4a42378b;path=/;secure;httponly
+      - __cfduid=ddca76a5467e92d2a3d823eb0dfc91fb51461460229; NSC_bqj-wjq-ttm=ffffffff09090e6d45525d5f4f58455e445a4a42378b;path=/;secure;httponly
   response:
     status:
       code: 301
@@ -201,7 +199,7 @@ http_interactions:
       Server:
       - cloudflare-nginx
       Date:
-      - Fri, 22 Apr 2016 06:12:49 GMT
+      - Sun, 24 Apr 2016 01:10:31 GMT
       Content-Type:
       - text/html; charset=utf-8
       Transfer-Encoding:
@@ -213,12 +211,12 @@ http_interactions:
       Location:
       - https://api.23andme.com/1/names/b9e65773cfcdadfd/
       Cf-Ray:
-      - 2976ed23225c1ffa-DFW
+      - 2985ad0cb42103e2-DFW
     body:
       encoding: UTF-8
       string: ''
     http_version: 
-  recorded_at: Fri, 22 Apr 2016 06:12:50 GMT
+  recorded_at: Sun, 24 Apr 2016 01:10:31 GMT
 - request:
     method: get
     uri: https://api.23andme.com/1/names/b9e65773cfcdadfd/
@@ -227,9 +225,9 @@ http_interactions:
       string: ''
     headers:
       Authorization:
-      - Bearer f8b7ad0e4a4283185390b47bc4124740
+      - Bearer 35f25c3211be51d4bfb5a0fd67f42ec0
       Cookie:
-      - __cfduid=db635c9ff24004bb1658a1064c209cf1c1461305568; NSC_bqj-wjq-ttm=ffffffff09090e6e45525d5f4f58455e445a4a42378b;path=/;secure;httponly
+      - __cfduid=ddca76a5467e92d2a3d823eb0dfc91fb51461460229; NSC_bqj-wjq-ttm=ffffffff09090e6d45525d5f4f58455e445a4a42378b;path=/;secure;httponly
   response:
     status:
       code: 200
@@ -238,7 +236,7 @@ http_interactions:
       Server:
       - cloudflare-nginx
       Date:
-      - Fri, 22 Apr 2016 06:12:50 GMT
+      - Sun, 24 Apr 2016 01:10:31 GMT
       Content-Type:
       - application/json
       Content-Length:
@@ -248,12 +246,12 @@ http_interactions:
       X-Frame-Options:
       - SAMEORIGIN
       Cf-Ray:
-      - 2976ed25476b263b-DFW
+      - 2985ad0e00261171-DFW
     body:
       encoding: UTF-8
       string: '{"first_name": "Heidi", "last_name": "Hoopes", "id": "b9e65773cfcdadfd"}'
     http_version: 
-  recorded_at: Fri, 22 Apr 2016 06:12:50 GMT
+  recorded_at: Sun, 24 Apr 2016 01:10:31 GMT
 - request:
     method: get
     uri: https://api.23andme.com/1/user
@@ -262,9 +260,9 @@ http_interactions:
       string: ''
     headers:
       Authorization:
-      - Bearer f8b7ad0e4a4283185390b47bc4124740
+      - Bearer 35f25c3211be51d4bfb5a0fd67f42ec0
       Cookie:
-      - __cfduid=db635c9ff24004bb1658a1064c209cf1c1461305568; NSC_bqj-wjq-ttm=ffffffff09090e6e45525d5f4f58455e445a4a42378b;path=/;secure;httponly
+      - __cfduid=ddca76a5467e92d2a3d823eb0dfc91fb51461460229; NSC_bqj-wjq-ttm=ffffffff09090e6d45525d5f4f58455e445a4a42378b;path=/;secure;httponly
   response:
     status:
       code: 301
@@ -273,79 +271,7 @@ http_interactions:
       Server:
       - cloudflare-nginx
       Date:
-      - Fri, 22 Apr 2016 06:12:50 GMT
-      Content-Type:
-      - Python/WSGI/Application
-      Content-Length:
-      - '0'
-      Connection:
-      - keep-alive
-      X-Frame-Options:
-      - SAMEORIGIN
-      Location:
-      - https://api.23andme.com/1/user/
-      Cf-Ray:
-      - 2976ed26b5bc1fc4-DFW
-    body:
-      encoding: UTF-8
-      string: ''
-    http_version: 
-  recorded_at: Fri, 22 Apr 2016 06:12:50 GMT
-- request:
-    method: get
-    uri: https://api.23andme.com/1/user/
-    body:
-      encoding: US-ASCII
-      string: ''
-    headers:
-      Authorization:
-      - Bearer f8b7ad0e4a4283185390b47bc4124740
-      Cookie:
-      - __cfduid=db635c9ff24004bb1658a1064c209cf1c1461305568; NSC_bqj-wjq-ttm=ffffffff09090e6e45525d5f4f58455e445a4a42378b;path=/;secure;httponly
-  response:
-    status:
-      code: 200
-      message: OK
-    headers:
-      Server:
-      - cloudflare-nginx
-      Date:
-      - Fri, 22 Apr 2016 06:12:50 GMT
-      Content-Type:
-      - application/json
-      Content-Length:
-      - '87'
-      Connection:
-      - keep-alive
-      X-Frame-Options:
-      - SAMEORIGIN
-      Cf-Ray:
-      - 2976ed280b200104-DFW
-    body:
-      encoding: UTF-8
-      string: '{"id": "f095cb38d4c563c9", "profiles": [{"genotyped": true, "id": "b9e65773cfcdadfd"}]}'
-    http_version: 
-  recorded_at: Fri, 22 Apr 2016 06:12:50 GMT
-- request:
-    method: get
-    uri: https://api.23andme.com/1/names/b9e65773cfcdadfd
-    body:
-      encoding: US-ASCII
-      string: ''
-    headers:
-      Authorization:
-      - Bearer f8b7ad0e4a4283185390b47bc4124740
-      Cookie:
-      - __cfduid=db635c9ff24004bb1658a1064c209cf1c1461305568; NSC_bqj-wjq-ttm=ffffffff09090e6e45525d5f4f58455e445a4a42378b;path=/;secure;httponly
-  response:
-    status:
-      code: 301
-      message: MOVED PERMANENTLY
-    headers:
-      Server:
-      - cloudflare-nginx
-      Date:
-      - Fri, 22 Apr 2016 06:12:50 GMT
+      - Sun, 24 Apr 2016 01:10:31 GMT
       Content-Type:
       - text/html; charset=utf-8
       Transfer-Encoding:
@@ -355,25 +281,25 @@ http_interactions:
       X-Frame-Options:
       - SAMEORIGIN
       Location:
-      - https://api.23andme.com/1/names/b9e65773cfcdadfd/
+      - https://api.23andme.com/1/user/
       Cf-Ray:
-      - 2976ed2972241ffa-DFW
+      - 2985ad106366263b-DFW
     body:
       encoding: UTF-8
       string: ''
     http_version: 
-  recorded_at: Fri, 22 Apr 2016 06:12:50 GMT
+  recorded_at: Sun, 24 Apr 2016 01:10:31 GMT
 - request:
     method: get
-    uri: https://api.23andme.com/1/names/b9e65773cfcdadfd/
+    uri: https://api.23andme.com/1/user/
     body:
       encoding: US-ASCII
       string: ''
     headers:
       Authorization:
-      - Bearer f8b7ad0e4a4283185390b47bc4124740
+      - Bearer 35f25c3211be51d4bfb5a0fd67f42ec0
       Cookie:
-      - __cfduid=db635c9ff24004bb1658a1064c209cf1c1461305568; NSC_bqj-wjq-ttm=ffffffff09090e6e45525d5f4f58455e445a4a42378b;path=/;secure;httponly
+      - __cfduid=ddca76a5467e92d2a3d823eb0dfc91fb51461460229; NSC_bqj-wjq-ttm=ffffffff09090e6d45525d5f4f58455e445a4a42378b;path=/;secure;httponly
   response:
     status:
       code: 200
@@ -382,7 +308,77 @@ http_interactions:
       Server:
       - cloudflare-nginx
       Date:
-      - Fri, 22 Apr 2016 06:12:51 GMT
+      - Sun, 24 Apr 2016 01:10:32 GMT
+      Content-Type:
+      - application/json
+      Content-Length:
+      - '87'
+      Connection:
+      - keep-alive
+      X-Frame-Options:
+      - SAMEORIGIN
+      Cf-Ray:
+      - 2985ad1190761171-DFW
+    body:
+      encoding: UTF-8
+      string: '{"id": "f095cb38d4c563c9", "profiles": [{"genotyped": true, "id": "b9e65773cfcdadfd"}]}'
+    http_version: 
+  recorded_at: Sun, 24 Apr 2016 01:10:32 GMT
+- request:
+    method: get
+    uri: https://api.23andme.com/1/names/b9e65773cfcdadfd
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Authorization:
+      - Bearer 35f25c3211be51d4bfb5a0fd67f42ec0
+      Cookie:
+      - __cfduid=ddca76a5467e92d2a3d823eb0dfc91fb51461460229; NSC_bqj-wjq-ttm=ffffffff09090e6d45525d5f4f58455e445a4a42378b;path=/;secure;httponly
+  response:
+    status:
+      code: 301
+      message: MOVED PERMANENTLY
+    headers:
+      Server:
+      - cloudflare-nginx
+      Date:
+      - Sun, 24 Apr 2016 01:10:32 GMT
+      Content-Length:
+      - '0'
+      Connection:
+      - keep-alive
+      X-Frame-Options:
+      - SAMEORIGIN
+      Location:
+      - https://api.23andme.com/1/names/b9e65773cfcdadfd/
+      Cf-Ray:
+      - 2985ad13150f0106-DFW
+    body:
+      encoding: UTF-8
+      string: ''
+    http_version: 
+  recorded_at: Sun, 24 Apr 2016 01:10:32 GMT
+- request:
+    method: get
+    uri: https://api.23andme.com/1/names/b9e65773cfcdadfd/
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Authorization:
+      - Bearer 35f25c3211be51d4bfb5a0fd67f42ec0
+      Cookie:
+      - __cfduid=ddca76a5467e92d2a3d823eb0dfc91fb51461460229; NSC_bqj-wjq-ttm=ffffffff09090e6d45525d5f4f58455e445a4a42378b;path=/;secure;httponly
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Server:
+      - cloudflare-nginx
+      Date:
+      - Sun, 24 Apr 2016 01:10:32 GMT
       Content-Type:
       - application/json
       Content-Length:
@@ -392,10 +388,10 @@ http_interactions:
       X-Frame-Options:
       - SAMEORIGIN
       Cf-Ray:
-      - 2976ed2aa79b1189-DFW
+      - 2985ad146c6003e2-DFW
     body:
       encoding: UTF-8
       string: '{"first_name": "Heidi", "last_name": "Hoopes", "id": "b9e65773cfcdadfd"}'
     http_version: 
-  recorded_at: Fri, 22 Apr 2016 06:12:51 GMT
+  recorded_at: Sun, 24 Apr 2016 01:10:32 GMT
 recorded_with: VCR 3.0.1

--- a/spec/cassettes/user_service.yml
+++ b/spec/cassettes/user_service.yml
@@ -8,7 +8,7 @@ http_interactions:
       string: ''
     headers:
       Authorization:
-      - Bearer f8b7ad0e4a4283185390b47bc4124740
+      - Bearer 35f25c3211be51d4bfb5a0fd67f42ec0
   response:
     status:
       code: 301
@@ -17,26 +17,26 @@ http_interactions:
       Server:
       - cloudflare-nginx
       Date:
-      - Fri, 22 Apr 2016 05:49:59 GMT
+      - Sun, 24 Apr 2016 01:10:33 GMT
       Content-Length:
       - '0'
       Connection:
       - keep-alive
       Set-Cookie:
-      - NSC_bqj-wjq-ttm=ffffffff09090e6b45525d5f4f58455e445a4a42378b;path=/;secure;httponly
-      - __cfduid=d45694ae90ea19dded245815032c7b9c31461304199; expires=Sat, 22-Apr-17
-        05:49:59 GMT; path=/; domain=.23andme.com; HttpOnly
+      - NSC_bqj-wjq-ttm=ffffffff09090e6f45525d5f4f58455e445a4a42378b;path=/;secure;httponly
+      - __cfduid=d4e045e739beb83ccefdf982ab70b85881461460233; expires=Mon, 24-Apr-17
+        01:10:33 GMT; path=/; domain=.23andme.com; HttpOnly
       X-Frame-Options:
       - SAMEORIGIN
       Location:
       - https://api.23andme.com/1/user/
       Cf-Ray:
-      - 2976cbae2ef4263b-DFW
+      - 2985ad1bdda22030-DFW
     body:
       encoding: UTF-8
       string: ''
     http_version: 
-  recorded_at: Fri, 22 Apr 2016 05:49:59 GMT
+  recorded_at: Sun, 24 Apr 2016 01:10:33 GMT
 - request:
     method: get
     uri: https://api.23andme.com/1/user/
@@ -45,9 +45,9 @@ http_interactions:
       string: ''
     headers:
       Authorization:
-      - Bearer f8b7ad0e4a4283185390b47bc4124740
+      - Bearer 35f25c3211be51d4bfb5a0fd67f42ec0
       Cookie:
-      - __cfduid=d45694ae90ea19dded245815032c7b9c31461304199; NSC_bqj-wjq-ttm=ffffffff09090e6b45525d5f4f58455e445a4a42378b;path=/;secure;httponly
+      - __cfduid=d4e045e739beb83ccefdf982ab70b85881461460233; NSC_bqj-wjq-ttm=ffffffff09090e6f45525d5f4f58455e445a4a42378b;path=/;secure;httponly
   response:
     status:
       code: 200
@@ -56,7 +56,7 @@ http_interactions:
       Server:
       - cloudflare-nginx
       Date:
-      - Fri, 22 Apr 2016 05:50:00 GMT
+      - Sun, 24 Apr 2016 01:10:33 GMT
       Content-Type:
       - application/json
       Content-Length:
@@ -66,12 +66,12 @@ http_interactions:
       X-Frame-Options:
       - SAMEORIGIN
       Cf-Ray:
-      - 2976cbb13a320968-DFW
+      - 2985ad1d16d82623-DFW
     body:
       encoding: UTF-8
       string: '{"id": "f095cb38d4c563c9", "profiles": [{"genotyped": true, "id": "b9e65773cfcdadfd"}]}'
     http_version: 
-  recorded_at: Fri, 22 Apr 2016 05:50:00 GMT
+  recorded_at: Sun, 24 Apr 2016 01:10:33 GMT
 - request:
     method: get
     uri: https://api.23andme.com/1/user/?email=true
@@ -80,9 +80,9 @@ http_interactions:
       string: ''
     headers:
       Authorization:
-      - Bearer f8b7ad0e4a4283185390b47bc4124740
+      - Bearer 35f25c3211be51d4bfb5a0fd67f42ec0
       Cookie:
-      - __cfduid=d45694ae90ea19dded245815032c7b9c31461304199; NSC_bqj-wjq-ttm=ffffffff09090e6b45525d5f4f58455e445a4a42378b;path=/;secure;httponly
+      - __cfduid=d4e045e739beb83ccefdf982ab70b85881461460233; NSC_bqj-wjq-ttm=ffffffff09090e6f45525d5f4f58455e445a4a42378b;path=/;secure;httponly
   response:
     status:
       code: 200
@@ -91,7 +91,7 @@ http_interactions:
       Server:
       - cloudflare-nginx
       Date:
-      - Fri, 22 Apr 2016 05:50:00 GMT
+      - Sun, 24 Apr 2016 01:10:34 GMT
       Content-Type:
       - application/json
       Content-Length:
@@ -101,13 +101,13 @@ http_interactions:
       X-Frame-Options:
       - SAMEORIGIN
       Cf-Ray:
-      - 2976cbb3b2e603dc-DFW
+      - 2985ad1ec55d0106-DFW
     body:
       encoding: UTF-8
       string: '{"id": "f095cb38d4c563c9", "profiles": [{"genotyped": true, "id": "b9e65773cfcdadfd"}],
         "email": "heidih@gmail.com"}'
     http_version: 
-  recorded_at: Fri, 22 Apr 2016 05:50:00 GMT
+  recorded_at: Sun, 24 Apr 2016 01:10:34 GMT
 - request:
     method: get
     uri: https://api.23andme.com/1/user
@@ -116,9 +116,9 @@ http_interactions:
       string: ''
     headers:
       Authorization:
-      - Bearer f8b7ad0e4a4283185390b47bc4124740
+      - Bearer 35f25c3211be51d4bfb5a0fd67f42ec0
       Cookie:
-      - __cfduid=d45694ae90ea19dded245815032c7b9c31461304199; NSC_bqj-wjq-ttm=ffffffff09090e6b45525d5f4f58455e445a4a42378b;path=/;secure;httponly
+      - __cfduid=d4e045e739beb83ccefdf982ab70b85881461460233; NSC_bqj-wjq-ttm=ffffffff09090e6f45525d5f4f58455e445a4a42378b;path=/;secure;httponly
   response:
     status:
       code: 301
@@ -127,9 +127,7 @@ http_interactions:
       Server:
       - cloudflare-nginx
       Date:
-      - Fri, 22 Apr 2016 05:50:00 GMT
-      Content-Type:
-      - Python/WSGI/Response
+      - Sun, 24 Apr 2016 01:10:34 GMT
       Content-Length:
       - '0'
       Connection:
@@ -139,12 +137,12 @@ http_interactions:
       Location:
       - https://api.23andme.com/1/user/
       Cf-Ray:
-      - 2976cbb53ac81ffa-DFW
+      - 2985ad2029d82030-DFW
     body:
       encoding: UTF-8
       string: ''
     http_version: 
-  recorded_at: Fri, 22 Apr 2016 05:50:00 GMT
+  recorded_at: Sun, 24 Apr 2016 01:10:34 GMT
 - request:
     method: get
     uri: https://api.23andme.com/1/user/
@@ -153,9 +151,9 @@ http_interactions:
       string: ''
     headers:
       Authorization:
-      - Bearer f8b7ad0e4a4283185390b47bc4124740
+      - Bearer 35f25c3211be51d4bfb5a0fd67f42ec0
       Cookie:
-      - __cfduid=d45694ae90ea19dded245815032c7b9c31461304199; NSC_bqj-wjq-ttm=ffffffff09090e6b45525d5f4f58455e445a4a42378b;path=/;secure;httponly
+      - __cfduid=d4e045e739beb83ccefdf982ab70b85881461460233; NSC_bqj-wjq-ttm=ffffffff09090e6f45525d5f4f58455e445a4a42378b;path=/;secure;httponly
   response:
     status:
       code: 200
@@ -164,7 +162,7 @@ http_interactions:
       Server:
       - cloudflare-nginx
       Date:
-      - Fri, 22 Apr 2016 05:50:00 GMT
+      - Sun, 24 Apr 2016 01:10:34 GMT
       Content-Type:
       - application/json
       Content-Length:
@@ -174,12 +172,12 @@ http_interactions:
       X-Frame-Options:
       - SAMEORIGIN
       Cf-Ray:
-      - 2976cbb66bed1ffa-DFW
+      - 2985ad217a1c1fc4-DFW
     body:
       encoding: UTF-8
       string: '{"id": "f095cb38d4c563c9", "profiles": [{"genotyped": true, "id": "b9e65773cfcdadfd"}]}'
     http_version: 
-  recorded_at: Fri, 22 Apr 2016 05:50:00 GMT
+  recorded_at: Sun, 24 Apr 2016 01:10:34 GMT
 - request:
     method: get
     uri: https://api.23andme.com/1/names/b9e65773cfcdadfd
@@ -188,9 +186,9 @@ http_interactions:
       string: ''
     headers:
       Authorization:
-      - Bearer f8b7ad0e4a4283185390b47bc4124740
+      - Bearer 35f25c3211be51d4bfb5a0fd67f42ec0
       Cookie:
-      - __cfduid=d45694ae90ea19dded245815032c7b9c31461304199; NSC_bqj-wjq-ttm=ffffffff09090e6b45525d5f4f58455e445a4a42378b;path=/;secure;httponly
+      - __cfduid=d4e045e739beb83ccefdf982ab70b85881461460233; NSC_bqj-wjq-ttm=ffffffff09090e6f45525d5f4f58455e445a4a42378b;path=/;secure;httponly
   response:
     status:
       code: 301
@@ -199,7 +197,9 @@ http_interactions:
       Server:
       - cloudflare-nginx
       Date:
-      - Fri, 22 Apr 2016 05:50:01 GMT
+      - Sun, 24 Apr 2016 01:10:34 GMT
+      Content-Type:
+      - Python/WSGI/Application
       Content-Length:
       - '0'
       Connection:
@@ -209,12 +209,12 @@ http_interactions:
       Location:
       - https://api.23andme.com/1/names/b9e65773cfcdadfd/
       Cf-Ray:
-      - 2976cbb8cbb203dc-DFW
+      - 2985ad23de8e0932-DFW
     body:
       encoding: UTF-8
       string: ''
     http_version: 
-  recorded_at: Fri, 22 Apr 2016 05:50:01 GMT
+  recorded_at: Sun, 24 Apr 2016 01:10:34 GMT
 - request:
     method: get
     uri: https://api.23andme.com/1/names/b9e65773cfcdadfd/
@@ -223,9 +223,9 @@ http_interactions:
       string: ''
     headers:
       Authorization:
-      - Bearer f8b7ad0e4a4283185390b47bc4124740
+      - Bearer 35f25c3211be51d4bfb5a0fd67f42ec0
       Cookie:
-      - __cfduid=d45694ae90ea19dded245815032c7b9c31461304199; NSC_bqj-wjq-ttm=ffffffff09090e6b45525d5f4f58455e445a4a42378b;path=/;secure;httponly
+      - __cfduid=d4e045e739beb83ccefdf982ab70b85881461460233; NSC_bqj-wjq-ttm=ffffffff09090e6f45525d5f4f58455e445a4a42378b;path=/;secure;httponly
   response:
     status:
       code: 200
@@ -234,7 +234,7 @@ http_interactions:
       Server:
       - cloudflare-nginx
       Date:
-      - Fri, 22 Apr 2016 05:50:01 GMT
+      - Sun, 24 Apr 2016 01:10:35 GMT
       Content-Type:
       - application/json
       Content-Length:
@@ -244,12 +244,12 @@ http_interactions:
       X-Frame-Options:
       - SAMEORIGIN
       Cf-Ray:
-      - 2976cbba507b03e2-DFW
+      - 2985ad250fe90106-DFW
     body:
       encoding: UTF-8
       string: '{"first_name": "Heidi", "last_name": "Hoopes", "id": "b9e65773cfcdadfd"}'
     http_version: 
-  recorded_at: Fri, 22 Apr 2016 05:50:01 GMT
+  recorded_at: Sun, 24 Apr 2016 01:10:35 GMT
 - request:
     method: get
     uri: https://api.23andme.com/1/user
@@ -258,9 +258,9 @@ http_interactions:
       string: ''
     headers:
       Authorization:
-      - Bearer f8b7ad0e4a4283185390b47bc4124740
+      - Bearer 35f25c3211be51d4bfb5a0fd67f42ec0
       Cookie:
-      - __cfduid=d45694ae90ea19dded245815032c7b9c31461304199; NSC_bqj-wjq-ttm=ffffffff09090e6b45525d5f4f58455e445a4a42378b;path=/;secure;httponly
+      - __cfduid=d4e045e739beb83ccefdf982ab70b85881461460233; NSC_bqj-wjq-ttm=ffffffff09090e6f45525d5f4f58455e445a4a42378b;path=/;secure;httponly
   response:
     status:
       code: 301
@@ -269,11 +269,11 @@ http_interactions:
       Server:
       - cloudflare-nginx
       Date:
-      - Fri, 22 Apr 2016 05:50:01 GMT
+      - Sun, 24 Apr 2016 01:10:35 GMT
       Content-Type:
-      - text/html; charset=utf-8
-      Transfer-Encoding:
-      - chunked
+      - Python/WSGI/Application
+      Content-Length:
+      - '0'
       Connection:
       - keep-alive
       X-Frame-Options:
@@ -281,12 +281,12 @@ http_interactions:
       Location:
       - https://api.23andme.com/1/user/
       Cf-Ray:
-      - 2976cbbbd02e0932-DFW
+      - 2985ad267f2b2030-DFW
     body:
       encoding: UTF-8
       string: ''
     http_version: 
-  recorded_at: Fri, 22 Apr 2016 05:50:01 GMT
+  recorded_at: Sun, 24 Apr 2016 01:10:35 GMT
 - request:
     method: get
     uri: https://api.23andme.com/1/user/
@@ -295,9 +295,9 @@ http_interactions:
       string: ''
     headers:
       Authorization:
-      - Bearer f8b7ad0e4a4283185390b47bc4124740
+      - Bearer 35f25c3211be51d4bfb5a0fd67f42ec0
       Cookie:
-      - __cfduid=d45694ae90ea19dded245815032c7b9c31461304199; NSC_bqj-wjq-ttm=ffffffff09090e6b45525d5f4f58455e445a4a42378b;path=/;secure;httponly
+      - __cfduid=d4e045e739beb83ccefdf982ab70b85881461460233; NSC_bqj-wjq-ttm=ffffffff09090e6f45525d5f4f58455e445a4a42378b;path=/;secure;httponly
   response:
     status:
       code: 200
@@ -306,7 +306,7 @@ http_interactions:
       Server:
       - cloudflare-nginx
       Date:
-      - Fri, 22 Apr 2016 05:50:01 GMT
+      - Sun, 24 Apr 2016 01:10:35 GMT
       Content-Type:
       - application/json
       Content-Length:
@@ -316,12 +316,12 @@ http_interactions:
       X-Frame-Options:
       - SAMEORIGIN
       Cf-Ray:
-      - 2976cbbd0c462030-DFW
+      - 2985ad27c3f91189-DFW
     body:
       encoding: UTF-8
       string: '{"id": "f095cb38d4c563c9", "profiles": [{"genotyped": true, "id": "b9e65773cfcdadfd"}]}'
     http_version: 
-  recorded_at: Fri, 22 Apr 2016 05:50:01 GMT
+  recorded_at: Sun, 24 Apr 2016 01:10:35 GMT
 - request:
     method: get
     uri: https://api.23andme.com/1/names/b9e65773cfcdadfd
@@ -330,9 +330,9 @@ http_interactions:
       string: ''
     headers:
       Authorization:
-      - Bearer f8b7ad0e4a4283185390b47bc4124740
+      - Bearer 35f25c3211be51d4bfb5a0fd67f42ec0
       Cookie:
-      - __cfduid=d45694ae90ea19dded245815032c7b9c31461304199; NSC_bqj-wjq-ttm=ffffffff09090e6b45525d5f4f58455e445a4a42378b;path=/;secure;httponly
+      - __cfduid=d4e045e739beb83ccefdf982ab70b85881461460233; NSC_bqj-wjq-ttm=ffffffff09090e6f45525d5f4f58455e445a4a42378b;path=/;secure;httponly
   response:
     status:
       code: 301
@@ -341,7 +341,7 @@ http_interactions:
       Server:
       - cloudflare-nginx
       Date:
-      - Fri, 22 Apr 2016 05:50:02 GMT
+      - Sun, 24 Apr 2016 01:10:35 GMT
       Content-Type:
       - text/html; charset=utf-8
       Transfer-Encoding:
@@ -353,12 +353,12 @@ http_interactions:
       Location:
       - https://api.23andme.com/1/names/b9e65773cfcdadfd/
       Cf-Ray:
-      - 2976cbbeb85c03e2-DFW
+      - 2985ad29edaf0106-DFW
     body:
       encoding: UTF-8
       string: ''
     http_version: 
-  recorded_at: Fri, 22 Apr 2016 05:50:02 GMT
+  recorded_at: Sun, 24 Apr 2016 01:10:35 GMT
 - request:
     method: get
     uri: https://api.23andme.com/1/names/b9e65773cfcdadfd/
@@ -367,9 +367,9 @@ http_interactions:
       string: ''
     headers:
       Authorization:
-      - Bearer f8b7ad0e4a4283185390b47bc4124740
+      - Bearer 35f25c3211be51d4bfb5a0fd67f42ec0
       Cookie:
-      - __cfduid=d45694ae90ea19dded245815032c7b9c31461304199; NSC_bqj-wjq-ttm=ffffffff09090e6b45525d5f4f58455e445a4a42378b;path=/;secure;httponly
+      - __cfduid=d4e045e739beb83ccefdf982ab70b85881461460233; NSC_bqj-wjq-ttm=ffffffff09090e6f45525d5f4f58455e445a4a42378b;path=/;secure;httponly
   response:
     status:
       code: 200
@@ -378,7 +378,7 @@ http_interactions:
       Server:
       - cloudflare-nginx
       Date:
-      - Fri, 22 Apr 2016 05:50:02 GMT
+      - Sun, 24 Apr 2016 01:10:36 GMT
       Content-Type:
       - application/json
       Content-Length:
@@ -388,10 +388,10 @@ http_interactions:
       X-Frame-Options:
       - SAMEORIGIN
       Cf-Ray:
-      - 2976cbc0069903e2-DFW
+      - 2985ad2b391e0932-DFW
     body:
       encoding: UTF-8
       string: '{"first_name": "Heidi", "last_name": "Hoopes", "id": "b9e65773cfcdadfd"}'
     http_version: 
-  recorded_at: Fri, 22 Apr 2016 05:50:02 GMT
+  recorded_at: Sun, 24 Apr 2016 01:10:36 GMT
 recorded_with: VCR 3.0.1

--- a/spec/factories.rb
+++ b/spec/factories.rb
@@ -4,26 +4,37 @@ FactoryGirl.define do
   end
   factory :snp_value do
     base_pair "MyString"
-    location "MyString"
-    snp nil
   end
   factory :snp do
-    snp_type "MyString"
+    snppable_type "user"
     snppable_id "MyString"
   end
   factory :study do
-    name "MyString"
+    sequence(:name) { | n| "Mitosis in Squirrels and Humans #{n}" }
     description "MyString"
   end
-  factory :researcher, class: ResearcherCredential do
-    description "MyString"
-    organization "MyOrganization"
-    user
+  factory :researcher, class: User do
+    first_name { Faker::Name.first_name }
+    last_name  { Faker::Name.last_name + ", PhD" }
+    password "MyString"
+    email { Faker::Internet.safe_email }
+    researcher_credential
+  end
+  factory :researcher_credential do
+    description "this stuff"
+    organization { Faker::University.name }
+  end
+  factory :participant, class: User do
+    first_name "MyString"
+    last_name "MyString"
+    password "MyString"
+    email "MyString"
+    participant_credential
   end
   factory :participant_credential do
-    access_token "MyString"
+    access_token ENV["ACCESS_TOKEN"]
     refresh_token "MyString"
-    uid "MyString"
+    uid "b9e65773cfcdadfd"
   end
   factory :user do
     first_name "MyString"

--- a/spec/features/participant_sees_matches_spec.rb
+++ b/spec/features/participant_sees_matches_spec.rb
@@ -1,0 +1,25 @@
+require 'rails_helper'
+
+feature "Participant sees matches" do
+  scenario "when they check their dashboard" do
+    participant = create(:participant)
+
+    researcher = create(:researcher)
+    researcher.studies << create(:study)
+    matching_study = Study.last
+    matching_study.snps << generated_snp("rs3094315", "AA", "study")
+
+    researcher2 = create(:researcher)
+    researcher2.studies << create(:study)
+    nonmatching_study = Study.last
+    nonmatching_study.snps << generated_snp("rs23364", "CC", "study")
+
+    log_in(participant)
+    visit dashboard_path
+
+    expect(page).to have_content("Your Research Studies")
+    expect(page).to have_content(researcher.researcher_credential.organization)
+    expect(page).to have_link(matching_study.name, study_path(matching_study))
+    expect(page).not_to have_link(nonmatching_study.name, study_path(nonmatching_study))
+  end
+end

--- a/spec/features/researcher_creates_study_spec.rb
+++ b/spec/features/researcher_creates_study_spec.rb
@@ -2,7 +2,7 @@ require 'rails_helper'
 
 feature "researcher creates new study" do
   scenario "and they see their new study on their dashboard" do
-    researcher = create(:researcher).user
+    researcher = create(:researcher)
     log_in(researcher)
 
     visit dashboard_path
@@ -23,10 +23,9 @@ feature "researcher creates new study" do
 
     study = Study.last
     expect(current_path).to eq(dashboard_path)
-
     expect(page).to have_content("Your Studies")
 
-    within("div.study-1") do
+    within("div.study-#{study.id}") do
       expect(page).to have_content("ADHD Genetic Research Study")
       expect(page).to have_content(study.description)
       expect(page).to have_content("rs3094315")

--- a/spec/features/visitor_logs_in_spec.rb
+++ b/spec/features/visitor_logs_in_spec.rb
@@ -2,7 +2,7 @@ require 'rails_helper'
 
 feature "Visitor logs in" do
   scenario "user is redirected to dashboard" do
-    user = create(:user, password: "password")
+    user = create(:participant, password: "password")
 
     visit "/"
     expect(page).not_to have_content("Welcome, #{user.full_name}")

--- a/spec/models/and_me_auth_service_spec.rb
+++ b/spec/models/and_me_auth_service_spec.rb
@@ -5,7 +5,7 @@ RSpec.describe AndMeAuthService do
     it "gets tokens back" do
 
       VCR.use_cassette("auth service and token") do
-        code = "117311b1980c7626e5020a943f2fa0d7"
+        code = "552ba8a755ed4878afcd567230b0141b"
         response = AndMeAuthService.get_token(code)
 
         expect(response[:refresh_token]).not_to be_nil

--- a/spec/models/snp_service_spec.rb
+++ b/spec/models/snp_service_spec.rb
@@ -1,0 +1,20 @@
+require 'rails_helper'
+
+RSpec.describe SnpService do
+  describe "it calls the api for a given location" do
+    it "receives base pair information" do
+      VCR.use_cassette("snp service") do
+        user = create(:participant)
+        user.participant_credential.uid = "b9e65773cfcdadfd"
+        token = valid_token
+        service = SnpService.new(token, user)
+
+        base_pair = service.find_basepairs("rs3094315")
+        expect(base_pair).to eq("AA")
+
+        nonexistent_pair = service.find_basepairs("garbage")
+        expect(nonexistent_pair).to be_nil
+      end
+    end
+  end
+end

--- a/spec/rails_helper.rb
+++ b/spec/rails_helper.rb
@@ -30,6 +30,7 @@ require 'vcr'
 ActiveRecord::Migration.maintain_test_schema!
 
 VCR.configure do |c|
+  c.allow_http_connections_when_no_cassette = true
   c.cassette_library_dir = "spec/cassettes"
   c.hook_into :webmock
 end

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -48,7 +48,7 @@ RSpec.configure do |config|
       "token_type"=>"bearer",
       "expires_in"=>86400,
       "refresh_token"=>"sample_refresh_token",
-      "scope"=>"profile:write haplogroups names ancestry basic email profile:read"}
+      "scope"=>"basic email genomes"}
   end
 
   def token_hash
@@ -68,5 +68,11 @@ RSpec.configure do |config|
     fill_in "Email", with: user.email
     fill_in "Password", with: user.password
     click_on "Login"
+  end
+
+  def generated_snp(position, base_pair, snppable_type)
+    location = Location.where(position: position).first_or_create
+    location.snp_values << SnpValue.where(base_pair: base_pair, location_id: location.id).first_or_create
+    create(:snp, snppable_type: snppable_type, snp_value: SnpValue.last)
   end
 end


### PR DESCRIPTION
Created a method for matching participants with studies where they both have the
same snp value, i.e., they have the same base pairs at a given location.

Required adding a new endpoint and service for 23 and Me. Tested the service that
was created for this. Added a feature test for a user's matches. Created a view
for the study which is currently empty, so needs a feature test for that.

Code could also be refactored to use AR queries.

Added activerecord-import to handle bulk importing snp locations to the database. Changed rake
task to reflect this.
