### PR TITLE
Add api route for snp verification

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -12,6 +12,7 @@ gem 'pg'
 gem 'httparty'
 gem 'rails_12factor', group: :production
 gem 'activerecord-import', '~> 0.4.0'
+gem 'responders', '~> 2.0'
 
 group :development, :test do
   gem 'pry'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -151,6 +151,8 @@ GEM
     rake (11.1.2)
     rdoc (4.2.2)
       json (~> 1.4)
+    responders (2.1.2)
+      railties (>= 4.2.0, < 5.1)
     rspec-core (3.4.4)
       rspec-support (~> 3.4.0)
     rspec-expectations (3.4.0)
@@ -242,6 +244,7 @@ DEPENDENCIES
   quiet_assets
   rails (= 4.2.5.1)
   rails_12factor
+  responders (~> 2.0)
   rspec-rails (~> 3.0)
   sass-rails (~> 5.0)
   sdoc (~> 0.4.0)

--- a/app/assets/javascripts/application.js
+++ b/app/assets/javascripts/application.js
@@ -14,3 +14,4 @@
 //= require jquery_ujs
 //= require_tree .
 //= require bootstrap-sprockets
+//= require new_study

--- a/app/assets/javascripts/new_study.js
+++ b/app/assets/javascripts/new_study.js
@@ -1,0 +1,21 @@
+$(document).ready(function(){
+  $("#snp-location-1").on('blur', verifyLocation);
+});
+
+function verifyLocation(){
+  var location = $("#snp-location-1").val();
+  $.ajax({
+    url: "/api/v1/verify_location/" + location,
+    method: "GET",
+    dataType: "json",
+    success: function(validity){
+      if(validity.validity == "true"){
+        $("#result").removeClass("glyphicon-remove");
+        $("#result").addClass("glyphicon-ok");
+      }
+      else{
+        $("#result").removeClass("glyphicon-ok").addClass("glyphicon-remove");
+      }
+    }
+  })
+}

--- a/app/controllers/api/api_controller.rb
+++ b/app/controllers/api/api_controller.rb
@@ -1,0 +1,6 @@
+module Api
+  class ApiController < ApplicationController
+    protect_from_forgery with: :null_session
+    respond_to :json
+  end
+end

--- a/app/controllers/api/v1/verify_location_controller.rb
+++ b/app/controllers/api/v1/verify_location_controller.rb
@@ -1,0 +1,18 @@
+module Api
+  module V1
+    class VerifyLocationController < ApiController
+
+      def show
+        validity = {}
+        location = Location.find_by(position: params[:id])
+        if location.nil?
+          validity["validity"] = "false"
+        else
+          validity["validity"] = "true"
+        end
+        respond_with validity 
+      end
+
+    end
+  end
+end

--- a/app/views/researcher/studies/new.html.erb
+++ b/app/views/researcher/studies/new.html.erb
@@ -14,9 +14,11 @@
         <%= snp_form.fields_for :snp_value do |snp_value_form| %>
           <p>
             <%= snp_value_form.fields_for :location do | location_form | %>
-              <p>location_form.label :position, "SNP Location" %>
+              <p><%= location_form.label :position, "SNP Location" %>
               <%= location_form.text_field :position, id: "snp-location-1", title: "The location of the SNP, e.g., rs3094315 or i3000001" %>
+              <span id="result" class="glyphicon"></span>
               </p>
+
             <% end %>
           <p>
             <%= snp_value_form.label :base_pair, "Base Pairs" %>

--- a/app/views/researcher/users/show.html.erb
+++ b/app/views/researcher/users/show.html.erb
@@ -1,13 +1,13 @@
 <div class="container researcher">
-  <h1>"Researcher Dashboard</h1>
+  <h1>Researcher Dashboard</h1>
 
   <h2>Your Studies</h2>
   <%= link_to "Create new study", new_researcher_study_path %>
 
   <% if @studies.empty? %>
-    <p>
-      We're sorry, no researchers have created studies at this time that match with your genome.
-    </p>
+  <p>
+    We're sorry, no researchers have created studies at this time that match with your genome.
+  </p>
   <% else %>
     <% @studies.each do | study | %>
       <div class="study-<%= study.id %>">

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -10,12 +10,17 @@ Rails.application.routes.draw do
     resources :studies, only: [:new, :create]
   end
 
+  namespace :api, defaults: { format: :json } do
+    namespace :v1 do
+      get "/verify_location/:id", to: "verify_location#show"
+    end
+  end
 
   namespace :participants do
   end
 
   resources :studies, only: [:show]
-  
+
   get "/dashboard", to: "users#show"
   post "/researcher_signup", to: "researcher/users#create"
 end

--- a/spec/api/v1/verifies_location_spec.rb
+++ b/spec/api/v1/verifies_location_spec.rb
@@ -1,0 +1,18 @@
+require 'rails_helper'
+
+describe "Verify Location API endpoints" do
+  it "returns true or false if a location is queriable by 23" do
+    real_location = Location.create(position: "rs28359175")
+
+    get "/api/v1/verify_location/#{real_location.position}"
+    json = JSON.parse(response.body)
+
+    expect(response).to be_success
+    expect(json["validity"]).to eq("true")
+
+    get "/api/v1/verify_location/sofake"
+    json = JSON.parse(response.body)
+    expect(response).to be_success
+    expect(json["validity"]).to eq("false")
+  end
+end


### PR DESCRIPTION
Added api route for verification of a snp's location. When a researcher creates
a new study, the form automatically verifies if a location is valid and provides
visual confirmation of such (or an "X" if it is invalid).

The endpoint is tested at the service level but a feature test could be used to
verify the ajax confirmation.
