### PR TITLE
Refactor generate.rake for heroku

### DIFF
--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -3,7 +3,6 @@
 <head>
   <title>GenomeMatchMaker</title>
   <%= stylesheet_link_tag    'application', media: 'all' %>
-  <%= javascript_include_tag 'application' %>
   <%= csrf_meta_tags %>
   <meta name="viewport" content="width=device-width, initial-scale=1"></head>
 <body>
@@ -14,4 +13,5 @@
   <%= yield %>
 
 </body>
+  <%= javascript_include_tag 'application' %>
 </html>

--- a/lib/tasks/generate.rake
+++ b/lib/tasks/generate.rake
@@ -7,19 +7,31 @@ namespace :import do
       positions = []
       CSV.foreach("data/partial_snps.csv", headers: true) do |row|
         entry = Location.new(position: row["snp"])
-          puts "Added #{row["index"]}" if row["index"].to_i % 10 == 0
-          positions << entry
+        positions << entry
+        if row["index"].to_i % 10 == 0
+          puts "Added #{row["index"]}"
+          Location.import positions
+          puts "Count: #{Location.count}"
+          positions = []
+        end
       end
       Location.import positions
+      puts "Final Count: #{Location.count}"
     end
 
-    desc "Import shortened snp location list"
-      task locations: :environment do
-        positions = []
-          CSV.foreach("data/full_snps.csv", headers: true) do |row|
-            positions << Location.new(position: row["snp"])
-            puts "Added #{row["index"]}" if row["index"].to_i % 100000 == 0
+  desc "Import all snp locations"
+    task locations: :environment do
+      positions = []
+        CSV.foreach("data/full_snps.csv", headers: true) do |row|
+          if row["index"].to_i % 10000 == 0
+            puts "Added ##{row["index"]}"
+            Location.import positions
+            positions = []
           end
-          import = Location.import positions
+          entry = Location.new(position: row["snp"])
+          positions << entry
+        end
+        Location.import positions
+        puts "Final Count: #{Location.count}"
       end
 end


### PR DESCRIPTION
The large import using activerecord-import relies on not saving until a huge
batch of files has been imported. This was more than the memory allocation at
Heroku allowed for. Hence, I shortened the batches to increments of 10000 rows.

closes #45 
