### PR TITLE
Add study show view for researcher and visitor

### DIFF
--- a/app/controllers/studies_controller.rb
+++ b/app/controllers/studies_controller.rb
@@ -2,5 +2,4 @@ class StudiesController < ApplicationController
   def show
     @study = Study.find(params[:id])
   end
-
 end

--- a/app/controllers/studies_controller.rb
+++ b/app/controllers/studies_controller.rb
@@ -1,5 +1,6 @@
 class StudiesController < ApplicationController
   def show
     @study = Study.find(params[:id])
+    MatchMaker.generate_matches([@study], User.participants)
   end
 end

--- a/app/views/studies/show.html.erb
+++ b/app/views/studies/show.html.erb
@@ -1,0 +1,18 @@
+<h1> <%= @study.name %></h1>
+<p><%= @study.user.researcher_credential.organization %>
+<p><%= @study.user.researcher_credential.description %>
+<p><%= @study.description %>
+<p>Based on the interactions of the <% @study.snps.each do |snp| %>
+  <%= snp.snp_value.base_pair %> mutation at the
+  <%= snp.snp_value.location.position %> position.
+<% end %>
+
+<% if current_user == @study.user %>
+  <h2>Participants ( <%= @study.study_participations.count %> total):</h2>
+  <ul>
+    <% @study.study_participations.each do | participation | %>
+      <li>Participant ID: <%= participation.user.id %>
+      <%= link_to "(Email Anonymously)", "mailto:anonymized@example.com" %></li>
+    <% end %>
+  </ul>
+<% end %>

--- a/lib/tasks/generate.rake
+++ b/lib/tasks/generate.rake
@@ -23,9 +23,9 @@ namespace :import do
     task locations: :environment do
       positions = []
         CSV.foreach("data/full_snps.csv", headers: true) do |row|
-          next if row["index"].to_i < 209000
+          # next if row["index"].to_i < 310000
           if row["index"].to_i % 50000 == 0
-            puts "Added ##{row["index"]}"
+            puts "Working on next batch from ##{row["index"]}"
             Location.import positions
             positions = []
           end

--- a/lib/tasks/generate.rake
+++ b/lib/tasks/generate.rake
@@ -23,7 +23,7 @@ namespace :import do
     task locations: :environment do
       positions = []
         CSV.foreach("data/full_snps.csv", headers: true) do |row|
-          # next if row["index"].to_i < 310000
+          next if row["index"].to_i < 600000
           if row["index"].to_i % 50000 == 0
             puts "Working on next batch from ##{row["index"]}"
             Location.import positions

--- a/lib/tasks/generate.rake
+++ b/lib/tasks/generate.rake
@@ -23,7 +23,8 @@ namespace :import do
     task locations: :environment do
       positions = []
         CSV.foreach("data/full_snps.csv", headers: true) do |row|
-          if row["index"].to_i % 100 == 0
+          next if row["index"].to_i < 209000
+          if row["index"].to_i % 50000 == 0
             puts "Added ##{row["index"]}"
             Location.import positions
             positions = []

--- a/spec/features/researcher_sees_participant_on_study_show_spec.rb
+++ b/spec/features/researcher_sees_participant_on_study_show_spec.rb
@@ -1,0 +1,25 @@
+require "rails_helper"
+
+feature "researcher views study show page" do
+  scenario "they see participant ids"  do
+    user = create(:researcher)
+    user.studies << create(:study)
+    study = Study.last
+    study.snps << generated_snp("rs103", "AA", "study")
+    participant = create(:participant)
+    study.study_participations <<
+      StudyParticipation.create(user_id: participant.id)
+    visit study_path(study)
+
+    expect(page).to have_content(study.name)
+    expect(page).to have_content(study.description)
+    expect(page).not_to have_content("Participants")
+    expect(page).not_to have_content("#{participant.id}")
+
+    log_in(user)
+    visit study_path(study)
+
+    expect(page).to have_content("Participants")
+    expect(page).to have_content("#{participant.id}")
+  end
+end

--- a/spec/features/researcher_views_study_page_spec.rb
+++ b/spec/features/researcher_views_study_page_spec.rb
@@ -1,3 +1,0 @@
-# expect(page).to have_content(participant.name)
-# expect(page).to have_content(participant.snps.last.snp_value.location.position)
-# expect(page).to have_link(participant.email)

--- a/spec/features/visitor_views_study_show_spec.rb
+++ b/spec/features/visitor_views_study_show_spec.rb
@@ -1,0 +1,16 @@
+require "rails_helper"
+
+feature "visitor views study show page" do
+  scenario "they see a study's information"  do
+    user = create(:researcher)
+    user.studies << create(:study)
+    study = Study.last
+    study.snps << generated_snp("rs103", "AA", "study")
+    visit study_path(study)
+
+    expect(page).to have_content(study.name)
+    expect(page).to have_content(study.description)
+    expect(page).to have_content(study.user.researcher_credential.organization)
+    expect(page).to have_content(study.snp_values.first.base_pair)
+  end
+end


### PR DESCRIPTION
Studies have their own page, where it shows the study information for a visitor, and participant contact information for the study's researcher.
