### PR TITLE
Add caching to 3 views that display participation matches

### DIFF
--- a/app/controllers/researcher/studies_controller.rb
+++ b/app/controllers/researcher/studies_controller.rb
@@ -6,11 +6,9 @@ class Researcher::StudiesController < ApplicationController
 
   def create
     @researcher = current_user
-    @researcher.studies << Study.new(study_params)
+    @researcher.studies << Study.create(study_params)
     @study = Study.last
-    if @study.save
-      redirect_to dashboard_path
-    end
+    redirect_to dashboard_path
   end
 
   private

--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -6,4 +6,8 @@ module ApplicationHelper
   def participant?
     current_user && current_user.participant?
   end
+
+  def study_participations_cache(view)
+    "#{view}-StudyParticipation-#{StudyParticipation.count}-#{StudyParticipation.maximum(:updated_at)}"
+  end
 end

--- a/app/views/participants/users/show.html.erb
+++ b/app/views/participants/users/show.html.erb
@@ -3,13 +3,15 @@
 <h2>Your Matching Studies</h2>
   <% if @user.study_participations %>
     <% @user.study_participations.each do | participation | %>
+    <% cache study_participations_cache("user-#{participation.id}") do %>
         <div class="study-<%= participation.study.id %>">
           <p><%= link_to participation.study.name, study_path(participation.study) %>
           <p><%= participation.study.user.researcher_credential.organization %>
           <p><%= participation.study.description %>
           <p>Based on your value of "<%= participation.study.snps.first.snp_value.base_pair %>"
             at the <%= participation.study.snps.first.snp_value.location.position %> position.
-      </div>
+        </div>
+    <% end %>
     <% end %>
   <% else %>
     <p>

--- a/app/views/researcher/users/show.html.erb
+++ b/app/views/researcher/users/show.html.erb
@@ -3,9 +3,10 @@
 
   <h2>Your Studies</h2>
 
-  <% if @studies.empty? %>
-    <p><%= link_to "Create new study", new_researcher_study_path %>
+  <p><%= link_to "Create new study", new_researcher_study_path %>
 
+  <% if @studies.empty? %>
+    You have no studies currently.
   <% else %>
     <% @studies.each do | study | %>
       <div class="study-<%= study.id %>">
@@ -13,6 +14,8 @@
         <p><%= study.description %> </p>
         <p> <% study.snps.each do |snp| %>
           SNP Location: <%= snp.snp_value.location.position + " (#{snp.snp_value.base_pair})" %>
+
+          <% cache study_participations_cache("researcher-#{study.id}-#{snp.id}") do %>
           <% if study.study_participations.empty? %>
             <p>
               This study has no matching participants.
@@ -21,6 +24,7 @@
             <p>
               This study has matching participants.
             </p>
+          <% end %>
           <% end %>
         <% end %>
       </div>

--- a/app/views/studies/show.html.erb
+++ b/app/views/studies/show.html.erb
@@ -1,3 +1,4 @@
+<% cache study_participations_cache("study") do %>
 <h1> <%= @study.name %></h1>
 <p><%= @study.user.researcher_credential.organization %>
 <p><%= @study.user.researcher_credential.description %>
@@ -15,4 +16,5 @@
       <%= link_to "(Email Anonymously)", "mailto:anonymized@example.com" %></li>
     <% end %>
   </ul>
+<% end %>
 <% end %>

--- a/config/environments/development.rb
+++ b/config/environments/development.rb
@@ -11,7 +11,7 @@ Rails.application.configure do
 
   # Show full error reports and disable caching.
   config.consider_all_requests_local       = true
-  config.action_controller.perform_caching = false
+  config.action_controller.perform_caching = true
 
   # Don't care if the mailer can't send.
   config.action_mailer.raise_delivery_errors = false


### PR DESCRIPTION
Created one caching method that takes in a view that reflects a unique name
for a particular view/study/snp combo (depending on what is required to make
that batch of information unique)

closes #48 
